### PR TITLE
adding build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: objective-c
+osx_image: xcode7.3
+script:
+  ./build.sh

--- a/NetworkState.podspec
+++ b/NetworkState.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   #
 
   s.name         = "NetworkState"
-  s.version      = "0.0.1"
+  s.version      = "0.0.2"
   s.summary      = "A very easy way to determine NetworkState"
 
   # This description is used to generate tags and improve search results.
@@ -65,8 +65,8 @@ Pod::Spec.new do |s|
   #  the deployment target. You can optionally include the target after the platform.
   #
 
-  s.platform     = :ios
-  # s.platform     = :ios, "5.0"
+  #s.platform     = :ios
+  s.platform     = :ios, "8.0"
 
   #  When using multiple platforms
   # s.ios.deployment_target = "5.0"
@@ -81,7 +81,7 @@ Pod::Spec.new do |s|
   #  Supports git, hg, bzr, svn and HTTP.
   #
 
-  s.source       = { :git => "https://github.com/garethpaul/NetworkState.git", :tag => "0.0.1" }
+  s.source       = { :git => "https://github.com/garethpaul/NetworkState.git", :tag => s.version}
 
 
   # ――― Source Code ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+set -eu
+
+function ci_lib() {
+    NAME=$1
+    xcodebuild -project NetworkState.xcodeproj \
+               -target "NetworkState" \
+               -destination "platform=iOS Simulator,name=${NAME}" \
+               -sdk iphonesimulator \
+               build test
+}
+
+ci_lib "iPhone 5"


### PR DESCRIPTION
## Summary

Add the repository's first macOS CI build script, configure Travis CI to invoke it with Xcode 7.3, and align the CocoaPods release metadata with version 0.0.2 and iOS 8.

## Baseline

The repository had no checked-in CI configuration or reusable Xcode build command. The podspec still declared version 0.0.1, an unspecified iOS platform target, and a fixed 0.0.1 source tag.

## Improvements

- Add `build.sh` to build the `NetworkState` target for an iPhone 5 simulator.
- Add `.travis.yml` using the historical Xcode 7.3 image.
- Update the podspec to version 0.0.2, iOS 8, and a source tag derived from the declared version.

## Validation

No GitHub check-run or status context is retained for this 2016 pull request. The merged diff records the intended Travis/Xcode build path, but this metadata update does not claim that the obsolete Xcode 7.3 environment was rerun.

## Risk

The CI and simulator assumptions are historical and obsolete on current hosted images. The original script used legacy shell and Xcode target conventions that were subsequently revised.

## Follow-Ups

Later pull requests replaced the legacy build assumptions with current shared schemes, fixture-based reachability tests, and protected GitHub Actions validation.
