### PR TITLE
Add Travis-Ci Btn

### DIFF
--- a/NetworkState.podspec
+++ b/NetworkState.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   #
 
   s.name         = "NetworkState"
-  s.version      = "0.0.1"
+  s.version      = "0.0.2"
   s.summary      = "A very easy way to determine NetworkState"
 
   # This description is used to generate tags and improve search results.
@@ -65,8 +65,8 @@ Pod::Spec.new do |s|
   #  the deployment target. You can optionally include the target after the platform.
   #
 
-  s.platform     = :ios
-  # s.platform     = :ios, "5.0"
+  #s.platform     = :ios
+  s.platform     = :ios, "8.0"
 
   #  When using multiple platforms
   # s.ios.deployment_target = "5.0"
@@ -81,7 +81,7 @@ Pod::Spec.new do |s|
   #  Supports git, hg, bzr, svn and HTTP.
   #
 
-  s.source       = { :git => "https://github.com/garethpaul/NetworkState.git", :tag => "0.0.1" }
+  s.source       = { :git => "https://github.com/garethpaul/NetworkState.git", :tag => s.version}
 
 
   # ――― Source Code ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/garethpaul/NetworkState.svg?branch=master)](https://travis-ci.org/garethpaul/NetworkState)
+
 # Network State
 
 Simply add the cocoapod to your pod file


### PR DESCRIPTION
## Summary

Add the historical Travis CI badge to the README and publish the CocoaPods metadata changes for version 0.0.2 with an explicit iOS 8 target.

## Baseline

The README did not expose build status, and the podspec still described version 0.0.1 with an unspecified iOS platform and fixed source tag.

## Improvements

- Add the Travis CI status badge for `master`.
- Declare pod version 0.0.2 and iOS 8 support.
- Derive the source tag from the podspec version.

## Validation

No GitHub check-run or status context is retained for this 2016 pull request. This metadata correction records the merged file changes without claiming that the retired Travis service or original package publication was rerun.

## Risk

The Travis badge is historical and the original CocoaPods publication environment is not reproduced. Later repository documentation and CI supersede these instructions.

## Follow-Ups

Current maintenance uses GitHub Actions, shared Xcode schemes, static baseline contracts, and modern security and contributor guidance.
