### PR TITLE
Cover automatic intervention matrix

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## 2026-06-10
 
+- Added an automatic intervention matrix covering on-demand, on-traffic, and
+  combined automatic connection flags while user action is required.
 - Added a non-reachability flag guard covering transient, local-address, and
   direct-route bits with and without the `Reachable` flag.
 - Added pinned, read-only macOS hosted validation for the SDK-free baseline and

--- a/NetworkStateTests/NetworkStateTests.swift
+++ b/NetworkStateTests/NetworkStateTests.swift
@@ -63,6 +63,19 @@ class NetworkStateTests: XCTestCase {
         XCTAssertFalse(NetworkState.isReachableWithFlags(SCNetworkReachabilityFlags(rawValue: reachable | interventionRequired)))
     }
 
+    func testAutomaticConnectionModesRequireNoUserIntervention() {
+        let reachable = UInt32(kSCNetworkFlagsReachable)
+        let connectionRequired = UInt32(kSCNetworkFlagsConnectionRequired)
+        let connectionOnDemand = UInt32(kSCNetworkFlagsConnectionOnDemand)
+        let connectionOnTraffic = UInt32(kSCNetworkFlagsConnectionOnTraffic)
+        let interventionRequired = UInt32(kSCNetworkFlagsInterventionRequired)
+        let requiredFlags = reachable | connectionRequired | interventionRequired
+
+        XCTAssertFalse(NetworkState.isReachableWithFlags(SCNetworkReachabilityFlags(rawValue: requiredFlags | connectionOnDemand)))
+        XCTAssertFalse(NetworkState.isReachableWithFlags(SCNetworkReachabilityFlags(rawValue: requiredFlags | connectionOnTraffic)))
+        XCTAssertFalse(NetworkState.isReachableWithFlags(SCNetworkReachabilityFlags(rawValue: requiredFlags | connectionOnDemand | connectionOnTraffic)))
+    }
+
     func testNonReachabilityFlagsDoNotCreateConnectivity() {
         let reachable = UInt32(kSCNetworkFlagsReachable)
         let transientConnection = UInt32(kSCNetworkFlagsTransientConnection)

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
   flag is present and no user intervention is required.
 - The intervention-required flag prevents reachability even when the base
   reachable flag is present.
+- The automatic intervention matrix covers on-demand, on-traffic, and combined
+  automatic modes so none report connectivity while user action is required.
 - The non-reachability flag guard verifies transient, local-address, and direct
   bits cannot create connectivity without the `Reachable` flag.
 - Open `NetworkState.xcodeproj` in Xcode and run the `NetworkStateTests` scheme.
@@ -114,6 +116,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   on-traffic states remain accepted together.
 - The intervention-required flag should keep user-action states from reporting
   connected.
+- The automatic intervention matrix should keep every automatic connection mode
+  unreachable while intervention is required.
 - Preserve the non-reachability flag guard when adding ancillary flag handling.
 - Review changes touching network requests, sockets, telemetry, or service endpoints; examples from the scan include NetworkState/Info.plist, NetworkStateTests/Info.plist.
 - Review changes touching file, media, JSON, XML, CSV, OCR, or data parsing; examples from the scan include NetworkState/Info.plist, NetworkStateTests/Info.plist.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -33,6 +33,8 @@ Helpful reports include:
   on-traffic states remain accepted together when reachable.
 - The intervention-required flag should prevent connectivity from being
   reported when the network state still needs user action.
+- The automatic intervention matrix should cover on-demand, on-traffic, and
+  combined automatic modes with user intervention required.
 - The non-reachability flag guard should ensure ancillary route flags cannot
   report connectivity without the `Reachable` bit.
 - Review found network clients, sockets, web APIs, or service endpoints; changes in those areas should receive security-focused review before merge.

--- a/VISION.md
+++ b/VISION.md
@@ -24,6 +24,7 @@ Priority:
 - Keep automatic connection behavior constrained so it requires the reachable flag
 - Keep combined automatic connection flags covered in fixture tests
 - Keep the intervention-required flag from reporting connectivity
+- Keep the automatic intervention matrix across every automatic connection mode
 - Keep the non-reachability flag guard around ancillary route flags
 - Avoid growing the library beyond focused reachability utilities
 - Keep `SystemConfiguration` checks local to the device

--- a/docs/plans/2026-06-12-automatic-intervention-matrix.md
+++ b/docs/plans/2026-06-12-automatic-intervention-matrix.md
@@ -1,6 +1,6 @@
 # Automatic Intervention Matrix
 
-status: planned
+status: completed
 
 ## Context
 
@@ -42,14 +42,20 @@ documentation.
 
 ## Verification
 
+Completed locally on 2026-06-12:
+
 - `python3 -m py_compile scripts/check-baseline.py`
 - `make lint`
 - `make test`
 - `make build`
 - `make check`
-- hostile mutations removing on-traffic or combined intervention coverage
+- hostile mutations removing on-traffic or combined intervention coverage were
+  each rejected by the static contract
 - `git diff --check`
-- hosted push and pull-request checks
+
+`xcodebuild` is unavailable on this Linux host, so XCTest was not executed
+locally. Hosted push and pull-request checks will be recorded after the branch
+is pushed.
 
 ## Boundaries
 

--- a/docs/plans/2026-06-12-automatic-intervention-matrix.md
+++ b/docs/plans/2026-06-12-automatic-intervention-matrix.md
@@ -1,0 +1,58 @@
+# Automatic Intervention Matrix
+
+status: planned
+
+## Context
+
+The reachability predicate rejects user-intervention-required states, including
+automatic connection modes. Existing XCTest coverage protects on-demand plus
+intervention, but not on-traffic or the combined automatic flags. A future
+condition refactor could therefore make one automatic mode report connectivity
+while still requiring user action.
+
+## Priorities
+
+1. Cover on-demand, on-traffic, and combined automatic modes with intervention.
+2. Require reachable and connection-required flags in each fixture.
+3. Preserve the production predicate and public API unchanged.
+4. Enforce the matrix through the portable static checker.
+
+## Implementation Units
+
+### XCTest Matrix
+
+File: `NetworkStateTests/NetworkStateTests.swift`
+
+Add a focused test asserting all three automatic-mode combinations remain
+unreachable when `kSCNetworkFlagsInterventionRequired` is present.
+
+### Static Contract And Documentation
+
+Files:
+
+- `scripts/check-baseline.py`
+- `README.md`
+- `SECURITY.md`
+- `VISION.md`
+- `CHANGES.md`
+- `docs/plans/2026-06-12-automatic-intervention-matrix.md`
+
+Require the three fixtures, completed evidence, and synchronized reachability
+documentation.
+
+## Verification
+
+- `python3 -m py_compile scripts/check-baseline.py`
+- `make lint`
+- `make test`
+- `make build`
+- `make check`
+- hostile mutations removing on-traffic or combined intervention coverage
+- `git diff --check`
+- hosted push and pull-request checks
+
+## Boundaries
+
+- Do not make live network requests or collect telemetry.
+- Do not change the public API or production flag predicate.
+- Do not claim XCTest execution without a compatible Xcode test environment.

--- a/docs/plans/2026-06-12-automatic-intervention-matrix.md
+++ b/docs/plans/2026-06-12-automatic-intervention-matrix.md
@@ -54,8 +54,13 @@ Completed locally on 2026-06-12:
 - `git diff --check`
 
 `xcodebuild` is unavailable on this Linux host, so XCTest was not executed
-locally. Hosted push and pull-request checks will be recorded after the branch
-is pushed.
+locally.
+
+Completed on hosted macOS for implementation head
+`70801c49325700194ab14fa3ea44a22c7747fc80`:
+
+- push run `27397655613`: success
+- pull-request run `27397656753`: success
 
 ## Boundaries
 

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -42,6 +42,7 @@ REQUIRED = [
     "docs/plans/2026-06-10-shared-framework-scheme-guard.md",
     "docs/plans/2026-06-10-non-reachability-flags.md",
     "docs/plans/2026-06-10-hosted-project-validation.md",
+    "docs/plans/2026-06-12-automatic-intervention-matrix.md",
     "docs/readme-overview.svg",
 ]
 
@@ -97,6 +98,15 @@ def main() -> int:
         failures.append("tests must cover combined automatic connection reachability flags")
     if "testInterventionRequiredFlagPreventsReachability" not in tests:
         failures.append("tests must cover intervention-required reachability flags")
+    automatic_intervention_test = tests.split("func testAutomaticConnectionModesRequireNoUserIntervention()", 1)[-1].split("func testNonReachabilityFlagsDoNotCreateConnectivity()", 1)[0]
+    if (
+        "func testAutomaticConnectionModesRequireNoUserIntervention()" not in tests
+        or "requiredFlags | connectionOnDemand" not in automatic_intervention_test
+        or "requiredFlags | connectionOnTraffic" not in automatic_intervention_test
+        or "requiredFlags | connectionOnDemand | connectionOnTraffic" not in automatic_intervention_test
+        or automatic_intervention_test.count("XCTAssertFalse") != 3
+    ):
+        failures.append("tests must cover intervention across every automatic connection mode")
     if (
         "testNonReachabilityFlagsDoNotCreateConnectivity" not in tests
         or "kSCNetworkFlagsTransientConnection" not in tests
@@ -181,6 +191,7 @@ def main() -> int:
         "requires the reachable flag",
         "combined automatic connection flags",
         "intervention-required flag",
+        "automatic intervention matrix",
         "iOS 8.0",
         "framework version alignment",
         "shared framework scheme",
@@ -235,6 +246,9 @@ def main() -> int:
     non_reachability_plan = read("docs/plans/2026-06-10-non-reachability-flags.md")
     if "status: completed" not in non_reachability_plan or "make check" not in non_reachability_plan:
         failures.append("non-reachability flag guard plan must record status and verification")
+    automatic_intervention_plan = read("docs/plans/2026-06-12-automatic-intervention-matrix.md")
+    if "status: completed" not in automatic_intervention_plan or "hostile mutations" not in automatic_intervention_plan:
+        failures.append("automatic intervention matrix plan must record completed verification")
 
     hosted_plan = read("docs/plans/2026-06-10-hosted-project-validation.md")
     workflow = read(".github/workflows/check.yml")


### PR DESCRIPTION
## Summary

The automatic intervention matrix now covers on-demand, on-traffic, and combined modes while preserving the production reachability predicate and public API.

## Baseline

Required-user-intervention behavior lacked complete mode-matrix coverage, leaving regressions in on-traffic or combined automatic modes easier to miss. The PR is clean and mergeable with two successful baseline checks, but local verification is static because Xcode is unavailable on Linux.

## Improvements

- cover on-demand, on-traffic, and combined automatic modes when user intervention is required
- preserve the existing production reachability predicate and public API
- enforce all three fixtures through the SDK-free static baseline
- document completed local verification and the XCTest execution boundary

## Validation

- `python3 -m py_compile scripts/check-baseline.py`
- `make lint`
- `make test`
- `make build`
- `make check`
- on-traffic and combined-matrix hostile mutations were rejected
- `git diff --check`

Local verification is static because `xcodebuild` is unavailable on Linux. Hosted macOS project parsing remains required.

## Risk

- Static fixtures prove source-level matrix coverage but do not execute XCTest, reachability callbacks, timing, notifications, or real network transitions.
- Preserving the predicate text does not prove equivalent behavior under concurrency or platform-specific reachability states.
- Automatic intervention decisions can affect user prompts, retries, background behavior, and connectivity recovery.

## Follow-Ups

- Run the XCTest suite with a compatible Xcode/macOS toolchain.
- Add executable cases for all mode combinations across reachable, unreachable, transitioning, background, and repeated callback states.
- Verify the public API and notification behavior remain compatible for existing consumers.
