### PR TITLE
ci: disable persisted checkout credentials

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,4 +14,6 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
       - run: make check

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## 2026-06-12
+
+- Disabled persisted checkout credentials and enforced the sole pinned
+  credential-free workflow boundary.
+
 ## 2026-06-10
 
 - Added an automatic intervention matrix covering on-demand, on-traffic, and

--- a/README.md
+++ b/README.md
@@ -90,7 +90,8 @@ DESTINATION='platform=iOS Simulator,name=iPhone 6' ./build.sh
 - `make check`
 - Pinned `macos-15` GitHub Actions runs the SDK-free baseline and parses
   `NetworkState.xcodeproj` without simulator execution, signing, pod
-  publishing, or runtime connectivity checks.
+  publishing, or runtime connectivity checks. Checkout credentials are not
+  persisted after source retrieval.
 - `./build.sh` on macOS with Xcode
 - `pod spec lint NetworkState.podspec` when preparing CocoaPods release metadata
 - XCTest coverage includes reachable, connection-required, and unreachable reachability flag combinations.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -64,6 +64,9 @@ files, and generated build products out of git. Preserve the shared framework
 scheme when changing project metadata so package verification remains
 repeatable.
 
+The hosted gate uses a credential-free checkout so its read-only token is not
+retained in the runner's Git configuration.
+
 ## Safe Research Guidelines
 
 Good-faith research is welcome when it stays within these boundaries:

--- a/VISION.md
+++ b/VISION.md
@@ -38,6 +38,7 @@ Priority:
   SDK-free static baseline
 - Keep hosted macOS project parsing pinned, read-only, and separate from the
   legacy simulator build
+- Keep hosted source retrieval credential-free after checkout
 
 Next priorities:
 

--- a/docs/plans/2026-06-12-checkout-credential-boundary.md
+++ b/docs/plans/2026-06-12-checkout-credential-boundary.md
@@ -1,0 +1,34 @@
+# Checkout Credential Boundary
+
+status: completed
+
+## Context
+
+The hosted macOS gate performs no authenticated Git operation after checkout,
+but the action default retained the read-only workflow token in the runner's
+Git configuration.
+
+## Implementation
+
+- Set `persist-credentials: false` on the single commit-pinned checkout step.
+- Require exactly one checkout action and only the canonical workflow file.
+- Preserve the macOS 15 runner, read-only permission, timeout, concurrency, and
+  `make check` command.
+- Document the credential-free checkout boundary.
+
+## Verification
+
+- `make lint`, `make test`, `make build`, and `make check` passed.
+- The checker passed from an external working directory.
+- Workflow YAML parsing, Python compilation, and `git diff --check` passed.
+- Focused hostile mutations rejected a missing or true credential setting,
+  duplicate checkout action, extra workflow file, incomplete plan, and stale
+  documentation; all hostile mutations rejected.
+- Exact-head hosted verification remains pending until this successor is
+  pushed.
+
+## Boundaries
+
+- Do not add post-checkout pushes, tags, or authenticated Git fetches.
+- Keep simulator execution, signing, pod publishing, and runtime connectivity
+  checks outside this static hosted gate.

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -43,6 +43,7 @@ REQUIRED = [
     "docs/plans/2026-06-10-non-reachability-flags.md",
     "docs/plans/2026-06-10-hosted-project-validation.md",
     "docs/plans/2026-06-12-automatic-intervention-matrix.md",
+    "docs/plans/2026-06-12-checkout-credential-boundary.md",
     "docs/readme-overview.svg",
 ]
 
@@ -264,6 +265,36 @@ def main() -> int:
     ]:
         if expected not in workflow:
             failures.append(f"Check workflow must keep {expected}")
+
+    checkout_plan = read("docs/plans/2026-06-12-checkout-credential-boundary.md")
+    if (
+        "status: completed" not in checkout_plan
+        or "persist-credentials: false" not in checkout_plan
+        or "hostile mutations rejected" not in checkout_plan
+    ):
+        failures.append("checkout credential plan must record completed verification")
+    workflow_files = sorted(
+        path.relative_to(ROOT).as_posix()
+        for path in (ROOT / ".github/workflows").iterdir()
+        if path.is_file()
+    )
+    if workflow_files != [".github/workflows/check.yml"]:
+        failures.append("workflow inventory must contain only .github/workflows/check.yml")
+    checkout_step = (
+        "      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10\n"
+        "        with:\n"
+        "          persist-credentials: false"
+    )
+    if workflow.count("actions/checkout@") != 1 or checkout_step not in workflow:
+        failures.append("Check workflow must keep one pinned credential-free checkout step")
+    if "persist-credentials: true" in workflow:
+        failures.append("Check workflow must not persist checkout credentials")
+    guidance = " ".join(
+        "\n".join(read(path) for path in ["README.md", "SECURITY.md", "VISION.md", "CHANGES.md"]).split()
+    ).lower()
+    for phrase in ["checkout credentials are not persisted", "credential-free checkout"]:
+        if phrase not in guidance:
+            failures.append(f"repository guidance must mention {phrase}")
 
     if shutil.which("xcodebuild"):
         result = subprocess.run(


### PR DESCRIPTION
## Summary

Stop retaining the read-only workflow token after source checkout.

## Baseline

PR #6 is the canonical static NetworkState validation base. Its pinned checkout used the default credential persistence behavior.

## Improvements

- Set `persist-credentials: false`.
- Require exactly one pinned checkout and only the canonical workflow.
- Document and enforce the credential-free boundary.

## Validation

- `make lint`, `make test`, `make build`, and `make check`
- external-working-directory checker
- workflow YAML parse, Python compilation, and `git diff --check`
- 6 focused hostile mutations

## Risk

Local Linux cannot run Xcode/SystemConfiguration behavior; hosted macOS exact-head verification remains pending. Runtime connectivity behavior is unchanged.

## Follow-Ups

This stacked PR should land after PR #6. No merge or closure is requested.