### PR TITLE
docs: document network reachability assumptions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # Changes
 
+## 2026-06-13
+
+- Documented the synchronous IPv4 default-route reachability semantics, the
+  request-level failures callers must still handle, the legacy iOS 8.0
+  compatibility boundary, and CocoaPods-only package support.
+- Enforced the local-only, no-remote-probe documentation contract in the static
+  baseline.
+
 ## 2026-06-12
 
 - Disabled persisted checkout credentials and enforced the sole pinned

--- a/README.md
+++ b/README.md
@@ -82,6 +82,22 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
 DESTINATION='platform=iOS Simulator,name=iPhone 6' ./build.sh
 ```
 
+## Platform, Packaging, And Reachability Assumptions
+
+- `isConnectedToNetwork()` is a synchronous snapshot of
+  `SCNetworkReachability` flags for the IPv4 default route. It does not monitor
+  later network changes.
+- A `true` result does not prove internet access, DNS resolution, captive-portal
+  completion, or availability of a specific service. Callers must still handle
+  request-level failures and timeouts.
+- The podspec declares iOS 8.0 because this is a legacy compatibility boundary,
+  not a claim that the project builds unchanged with current Xcode or Swift.
+- CocoaPods is the only declared package-manager integration. Swift Package
+  Manager and Carthage are unsupported unless added in a separate reviewed
+  change.
+- The helper evaluates local SystemConfiguration state only. It performs no
+  remote probes, telemetry, request logging, or endpoint availability checks.
+
 ## Testing and Verification
 
 - `make lint`

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,6 +26,9 @@ Helpful reports include:
 
 - This repository appears to be an Apple platform application or Swift sample. The active security scope is the code and documentation on the default branch.
 - The core code uses `SystemConfiguration` reachability. Connectivity checks should remain local to the device and should not collect telemetry, browsing data, endpoint history, or packet contents.
+- Reachability must remain a local flag snapshot with no remote probes. A
+  positive result must not be documented as proof of internet access, DNS,
+  captive-portal completion, or availability of a specific service.
 - Reachability flag evaluation should remain deterministic and covered without live network telemetry.
 - Automatic connection reachability flags should be evaluated locally and covered without live network telemetry.
 - Automatic connection handling should still require the reachable flag before reporting connectivity.
@@ -43,6 +46,9 @@ Helpful reports include:
   `make test`, `make build`, `make check`, and
   `pod spec lint NetworkState.podspec` before publishing package metadata
   changes.
+- CocoaPods is the only declared package-manager integration. Swift Package
+  Manager and Carthage support require separate metadata and verification
+  before being advertised.
 - The pinned macOS workflow runs static checks and project parsing without
   simulator execution, signing, pod publishing, or runtime connectivity checks.
 - The Xcode project and podspec should stay aligned on iOS 8.0 support so consumers do not receive inconsistent package metadata.

--- a/VISION.md
+++ b/VISION.md
@@ -39,13 +39,19 @@ Priority:
 - Keep hosted macOS project parsing pinned, read-only, and separate from the
   legacy simulator build
 - Keep hosted source retrieval credential-free after checkout
+- Keep the platform contract explicit: iOS 8.0 is a legacy package boundary,
+  not a current-Xcode compatibility claim
+- Keep reachability documented as a synchronous IPv4 default-route flag
+  snapshot rather than proof of internet or service availability
+- Keep CocoaPods as the only declared package-manager integration until another
+  manager is added and verified in a focused change
+- Keep connectivity evaluation local to the device with no remote probes,
+  telemetry, or endpoint checks
 
 Next priorities:
 
-- Document platform and network-framework assumptions
 - Modernize Swift/project settings in a dedicated pass
 - Add tests for offline, online, and constrained network cases where practical
-- Clarify package-manager support if revived
 - Run `pod spec lint NetworkState.podspec` on macOS before any package release
 
 Contribution rules:

--- a/docs/plans/2026-06-13-platform-network-assumptions.md
+++ b/docs/plans/2026-06-13-platform-network-assumptions.md
@@ -1,0 +1,67 @@
+---
+title: Document platform and network assumptions
+status: planned
+date: 2026-06-13
+---
+
+# Document Platform And Network Assumptions
+
+## Goal
+
+Make the supported platform, packaging, and reachability semantics explicit
+without changing the public `NetworkState.isConnectedToNetwork()` boolean API.
+
+## Decisions
+
+- Describe the helper as a synchronous snapshot of
+  `SCNetworkReachability` flags for the IPv4 default route.
+- State that a `true` result does not prove internet access, DNS resolution,
+  captive-portal completion, or availability of a specific service.
+- Preserve the current iOS 8.0 deployment target and legacy Swift/Xcode
+  compatibility boundary instead of claiming support for current toolchains.
+- Document CocoaPods as the only declared package-manager integration; Swift
+  Package Manager and Carthage remain unsupported unless added in a separate
+  reviewed change.
+- Keep reachability checks local to the device and free of telemetry, request
+  logging, or remote probes.
+
+## Implementation Units
+
+### Consumer documentation
+
+Files: `README.md`, `SECURITY.md`, `VISION.md`, `CHANGES.md`
+
+- Add a concise support and semantics section to the README.
+- Align security and vision language with the same local-only, no-probe
+  boundary.
+- Record the documentation contract in the changelog and mark the vision item
+  complete.
+
+### Regression contract
+
+Files: `scripts/check-baseline.py`
+
+- Require the README to retain the default-route snapshot limitation, the
+  non-guarantees for internet/service availability, the iOS 8.0 legacy
+  boundary, and CocoaPods-only package support.
+- Require security and vision documentation to retain the local-only/no-remote-
+  probe boundary.
+- Require this plan to record completed status and actual verification before
+  the full gate can pass.
+
+## Verification
+
+- Run `make lint`, `make test`, `make build`, and `make check`.
+- Run the checker from an external working directory.
+- Parse Python and workflow YAML, then run `git diff --check`.
+- Exercise hostile mutations that remove or weaken each documented assumption
+  and confirm the static gate rejects them.
+- Scan the intended diff for credential material and generated artifacts.
+
+## Risks
+
+- Documentation can overstate compatibility if it treats a metadata target as
+  proof of current Xcode support; wording must remain explicitly legacy-aware.
+- `SCNetworkReachability` flags are not a substitute for request-level error
+  handling, so the README must avoid presenting the helper as an internet
+  availability oracle.

--- a/docs/plans/2026-06-13-platform-network-assumptions.md
+++ b/docs/plans/2026-06-13-platform-network-assumptions.md
@@ -1,6 +1,6 @@
 ---
 title: Document platform and network assumptions
-status: planned
+status: completed
 date: 2026-06-13
 ---
 
@@ -65,3 +65,15 @@ Files: `scripts/check-baseline.py`
 - `SCNetworkReachability` flags are not a substitute for request-level error
   handling, so the README must avoid presenting the helper as an internet
   availability oracle.
+
+## Verification Result
+
+- `make lint`, `make test`, `make build`, and `make check` passed the complete
+  SDK-free baseline.
+- External-working-directory checker execution, Python compilation, workflow
+  YAML parsing, and `git diff --check` passed.
+- Six hostile mutations rejected weakened synchronous-snapshot, internet-
+  availability, package-manager, no-remote-probe, security non-guarantee, and
+  legacy-platform claims.
+- The intended documentation and checker diff passed credential-pattern and
+  generated-artifact scans.

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -44,6 +44,7 @@ REQUIRED = [
     "docs/plans/2026-06-10-hosted-project-validation.md",
     "docs/plans/2026-06-12-automatic-intervention-matrix.md",
     "docs/plans/2026-06-12-checkout-credential-boundary.md",
+    "docs/plans/2026-06-13-platform-network-assumptions.md",
     "docs/readme-overview.svg",
 ]
 
@@ -203,6 +204,41 @@ def main() -> int:
         if phrase not in docs:
             failures.append(f"docs must mention {phrase}")
 
+    readme = " ".join(read("README.md").split())
+    for phrase in [
+        "synchronous snapshot",
+        "IPv4 default route",
+        "does not prove internet access",
+        "DNS resolution",
+        "captive-portal completion",
+        "availability of a specific service",
+        "legacy compatibility boundary",
+        "CocoaPods is the only declared package-manager integration",
+        "Swift Package Manager and Carthage are unsupported",
+        "no remote probes",
+    ]:
+        if phrase not in readme:
+            failures.append(f"README platform assumptions must mention {phrase}")
+
+    security = " ".join(read("SECURITY.md").split())
+    for phrase in [
+        "local flag snapshot with no remote probes",
+        "must not be documented as proof of internet access",
+        "CocoaPods is the only declared package-manager integration",
+    ]:
+        if phrase not in security:
+            failures.append(f"security platform assumptions must mention {phrase}")
+
+    vision = " ".join(read("VISION.md").split())
+    for phrase in [
+        "iOS 8.0 is a legacy package boundary",
+        "synchronous IPv4 default-route flag snapshot",
+        "CocoaPods as the only declared package-manager integration",
+        "no remote probes",
+    ]:
+        if phrase not in vision:
+            failures.append(f"vision platform assumptions must mention {phrase}")
+
     plan = read("docs/plans/2026-06-08-network-state-baseline.md")
     if "status: completed" not in plan or "make check" not in plan:
         failures.append("completed plan must record status and verification")
@@ -273,6 +309,13 @@ def main() -> int:
         or "hostile mutations rejected" not in checkout_plan
     ):
         failures.append("checkout credential plan must record completed verification")
+    assumptions_plan = read("docs/plans/2026-06-13-platform-network-assumptions.md")
+    if (
+        "status: completed" not in assumptions_plan
+        or "make check" not in assumptions_plan
+        or "hostile mutations rejected" not in assumptions_plan
+    ):
+        failures.append("platform assumptions plan must record completed verification")
     workflow_files = sorted(
         path.relative_to(ROOT).as_posix()
         for path in (ROOT / ".github/workflows").iterdir()


### PR DESCRIPTION
## Summary

Consumers can now distinguish a local default-route reachability snapshot from proof that the internet, DNS, a captive portal, or a specific service is available. The documented support boundary also makes clear that iOS 8.0 is legacy package metadata and that CocoaPods is the only declared package-manager integration.

## Baseline

The public boolean API and deterministic flag predicate were already covered, but the repository did not state what a positive result cannot guarantee. Platform metadata could also be read as a current-Xcode support claim, and undeclared Swift Package Manager or Carthage support was ambiguous.

## Improvements

- Defines the helper as a synchronous IPv4 default-route `SCNetworkReachability` snapshot.
- Requires callers to retain request-level timeout and failure handling.
- Aligns README, security, vision, and changelog language around local-only evaluation with no remote probes or telemetry.
- Adds per-document static contracts so individual support and security claims cannot silently drift.

## Validation

- `make lint`, `make test`, `make build`, and `make check`
- External-working-directory checker execution
- Python compilation, workflow YAML parsing, and `git diff --check`
- Six hostile documentation mutations rejected
- Intended-path credential and generated-artifact scans

Local validation is SDK-free because this Linux host has no `xcodebuild`; no Swift runtime behavior changed.

## Risk

This is a documentation and verification-contract change only. It intentionally does not claim current Xcode compatibility, live network correctness, Swift Package Manager support, or Carthage support.

## Follow-Ups

- Modernize Swift and project settings in a separate focused change.
- Add practical offline, online, and constrained-network tests when a compatible Apple toolchain is available.
- Run `pod spec lint NetworkState.podspec` before any package release.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required. The branch changes documentation and static repository checks only; healthy delivery is both canonical GitHub Actions events passing at the exact head, and rollback is reverting the two branch commits if those checks expose an incorrect contract.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5.5-000000)
