### PR TITLE
fix: make NetworkState checks location-independent

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## 2026-06-13
 
+- Made every SDK-free Make alias resolve the static checker from the checkout
+  when the Makefile is invoked by absolute path.
 - Documented the synchronous IPv4 default-route reachability semantics, the
   request-level failures callers must still handle, the legacy iOS 8.0
   compatibility boundary, and CocoaPods-only package support.

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+
 .PHONY: build check lint static-check test verify
 
 check: verify
@@ -5,4 +7,4 @@ check: verify
 lint test build verify: static-check
 
 static-check:
-	python3 scripts/check-baseline.py
+	python3 "$(ROOT)/scripts/check-baseline.py"

--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
 - The non-reachability flag guard verifies transient, local-address, and direct
   bits cannot create connectivity without the `Reachable` flag.
 - Open `NetworkState.xcodeproj` in Xcode and run the `NetworkStateTests` scheme.
+- The Make gates are location-independent. From another directory, pass the
+  checkout's Makefile by absolute path, such as
+  `make -f /path/to/NetworkState/Makefile check`.
 - Run `./build.sh` when the required platform toolchain is installed. Override the simulator when needed:
 - The build script defaults `CODE_SIGNING_ALLOWED=NO` for simulator validation;
   override it only when intentionally testing signing behavior.
@@ -145,6 +148,7 @@ When the required SDK or runtime is unavailable, use static checks and source re
 - Run `make lint`, `make test`, `make build`, and `make check` before pushing
   changes, then run Xcode and CocoaPods verification on macOS when package
   metadata or Swift behavior changes.
+- Use an absolute Makefile path when running those gates outside the checkout.
 - Keep `NetworkState.podspec` and Xcode deployment targets aligned so package metadata does not claim unsupported iOS versions.
 - Keep framework version alignment between `NetworkState/Info.plist` and
   `NetworkState.podspec` before publishing package metadata.

--- a/docs/plans/2026-06-13-location-independent-make.md
+++ b/docs/plans/2026-06-13-location-independent-make.md
@@ -1,6 +1,6 @@
 # Location-Independent NetworkState Verification
 
-status: in progress
+status: completed
 
 ## Context
 
@@ -40,3 +40,25 @@ mutation verification after it completes.
 - Do not run dependency installation, builds, signing, simulators, remote
   probes, or application execution.
 - Preserve the existing stacked PR chain and exact-head evidence.
+
+## Work Completed
+
+- Rooted every SDK-free Make alias at the checkout containing the loaded
+  Makefile while preserving the existing target graph.
+- Added exact Makefile, README invocation, completed status, and verification
+  evidence contracts to `scripts/check-baseline.py`.
+- Documented absolute Makefile invocation without changing Swift, Xcode, or
+  workflow behavior.
+
+## Verification Completed
+
+- Root and external-directory `lint`, `test`, `build`, `verify`, and `check`
+  gates passed through the checkout's absolute Makefile path.
+- `python3 -m py_compile scripts/check-baseline.py` and `git diff --check`
+  passed.
+- Five isolated hostile mutations covering root derivation, checker resolution,
+  alias delegation, completed plan evidence, and README invocation guidance
+  were rejected by the intended contracts.
+- Intended-path, secret-pattern, conflict-marker, generated-artifact, Swift,
+  Xcode project, CocoaPods, test, workflow, and credential-boundary audits
+  passed.

--- a/docs/plans/2026-06-13-location-independent-make.md
+++ b/docs/plans/2026-06-13-location-independent-make.md
@@ -1,0 +1,42 @@
+# Location-Independent NetworkState Verification
+
+status: in progress
+
+## Context
+
+The SDK-free Make aliases invoke `scripts/check-baseline.py` relative to the
+caller's working directory. An absolute Makefile invocation from elsewhere can
+therefore fail or inspect the wrong tree instead of this checkout.
+
+## Objectives
+
+- Resolve every Make alias from the checkout containing the loaded Makefile.
+- Preserve the existing SDK-free target graph.
+- Enforce the exact rooted recipe, operator guidance, completed status, and
+  verification evidence in the active baseline checker.
+- Prove root and external-directory behavior with mutation-sensitive checks.
+
+## Implementation Units
+
+### Make Contract
+
+Files: `Makefile` and `scripts/check-baseline.py`.
+
+Derive one absolute root from the loaded Makefile and invoke the checker by
+absolute path. Require the complete small Makefile so aliases and path
+resolution cannot drift independently.
+
+### Documentation And Evidence
+
+Files: `README.md`, `CHANGES.md`, and this plan.
+
+Document absolute Makefile invocation and record bounded local and hostile
+mutation verification after it completes.
+
+## Boundaries
+
+- Do not change Swift, Xcode project files, CocoaPods metadata, tests,
+  workflows, or deployment targets.
+- Do not run dependency installation, builds, signing, simulators, remote
+  probes, or application execution.
+- Preserve the existing stacked PR chain and exact-head evidence.

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -11,6 +11,17 @@ import xml.etree.ElementTree as ET
 
 
 ROOT = Path(__file__).resolve().parents[1]
+EXPECTED_MAKEFILE = """ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+
+.PHONY: build check lint static-check test verify
+
+check: verify
+
+lint test build verify: static-check
+
+static-check:
+\tpython3 "$(ROOT)/scripts/check-baseline.py"
+"""
 REQUIRED = [
     ".gitignore",
     ".github/workflows/check.yml",
@@ -45,6 +56,7 @@ REQUIRED = [
     "docs/plans/2026-06-12-automatic-intervention-matrix.md",
     "docs/plans/2026-06-12-checkout-credential-boundary.md",
     "docs/plans/2026-06-13-platform-network-assumptions.md",
+    "docs/plans/2026-06-13-location-independent-make.md",
     "docs/readme-overview.svg",
 ]
 
@@ -127,13 +139,8 @@ def main() -> int:
         failures.append("build.sh must use POSIX shell function syntax or no shell functions")
 
     makefile = read("Makefile")
-    for phrase in [
-        ".PHONY: build check lint static-check test verify",
-        "check: verify",
-        "lint test build verify: static-check",
-    ]:
-        if phrase not in makefile:
-            failures.append(f"Makefile must include standard gate alias: {phrase}")
+    if makefile != EXPECTED_MAKEFILE:
+        failures.append("Makefile must exactly preserve rooted SDK-free aliases")
 
     podspec = read("NetworkState.podspec")
     podspec_version_match = re.search(r's\.version\s*=\s*"([^"]+)"', podspec)
@@ -182,7 +189,24 @@ def main() -> int:
         if expected not in gitignore:
             failures.append(f".gitignore must include {expected}")
 
-    docs = read("README.md") + "\n" + read("VISION.md") + "\n" + read("SECURITY.md")
+    readme_source = read("README.md")
+    docs = readme_source + "\n" + read("VISION.md") + "\n" + read("SECURITY.md")
+    location_independent_make_plan = read(
+        "docs/plans/2026-06-13-location-independent-make.md"
+    )
+    if "make -f /path/to/NetworkState/Makefile check" not in readme_source:
+        failures.append("README must document location-independent Makefile invocation")
+    if not all(
+        evidence in location_independent_make_plan.lower()
+        for evidence in [
+            "status: completed",
+            "root and external-directory",
+            "five isolated hostile mutations",
+        ]
+    ):
+        failures.append(
+            "location-independent Make plan must record completed root, external, and mutation verification"
+        )
     for phrase in [
         "make check",
         "pod spec lint",


### PR DESCRIPTION
## Summary

NetworkState's SDK-free verification can now run from any working directory through an absolute Makefile path. Every alias resolves the baseline checker from the checkout instead of depending on the caller's directory.

## Baseline

The existing Make targets invoked `scripts/check-baseline.py` with a relative path. External `make -f /absolute/path/Makefile check` invocations could fail or inspect the wrong tree despite the checker itself being checkout-aware.

## Improvements

The Makefile derives one checkout root from `MAKEFILE_LIST` while preserving the existing alias graph. The baseline checker now locks the complete rooted Makefile plus completed plan and README invocation evidence.

## Validation

- Root and external-directory `lint`, `test`, `build`, `verify`, and `check`
- `python3 -m py_compile scripts/check-baseline.py`
- Five isolated hostile mutations
- `git diff --check`
- Secret-pattern, conflict-marker, generated-artifact, and intended-path audits
- Both exact-head hosted `baseline` checks succeeded at `3bf488010c38fcebfab1e6e7e810dfc82cd70e06`.

## Risk

Local Linux validation cannot run `xcodebuild`; exact-head hosted macOS project parsing remains required. This PR does not modify Swift, Xcode project files, CocoaPods metadata, tests, workflows, or deployment targets.

## Follow-Ups

Merge the stacked base PR #8 before this PR. Canonical push and pull-request checks must be terminal-green at this exact head before owner merge.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
