### PR TITLE
Cover the WWAN reachability flag matrix

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## 2026-06-15
+
+- Added a WWAN reachability flag matrix covering the cellular bit with and
+  without the required `Reachable` flag.
+
 ## 2026-06-13
 
 - Made every SDK-free Make alias resolve the static checker from the checkout

--- a/NetworkStateTests/NetworkStateTests.swift
+++ b/NetworkStateTests/NetworkStateTests.swift
@@ -87,4 +87,12 @@ class NetworkStateTests: XCTestCase {
         XCTAssertTrue(NetworkState.isReachableWithFlags(SCNetworkReachabilityFlags(rawValue: reachable | ancillaryFlags)))
     }
 
+    func testWWANFlagRequiresReachableBaseFlag() {
+        let reachable = UInt32(kSCNetworkFlagsReachable)
+        let wwan = UInt32(kSCNetworkFlagsIsWWAN)
+
+        XCTAssertFalse(NetworkState.isReachableWithFlags(SCNetworkReachabilityFlags(rawValue: wwan)))
+        XCTAssertTrue(NetworkState.isReachableWithFlags(SCNetworkReachabilityFlags(rawValue: reachable | wwan)))
+    }
+
 }

--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
   automatic modes so none report connectivity while user action is required.
 - The non-reachability flag guard verifies transient, local-address, and direct
   bits cannot create connectivity without the `Reachable` flag.
+- The WWAN reachability flag matrix verifies the cellular bit cannot create
+  connectivity alone and remains accepted with `Reachable`.
 - Open `NetworkState.xcodeproj` in Xcode and run the `NetworkStateTests` scheme.
 - The Make gates are location-independent. From another directory, pass the
   checkout's Makefile by absolute path, such as
@@ -139,6 +141,7 @@ When the required SDK or runtime is unavailable, use static checks and source re
 - The automatic intervention matrix should keep every automatic connection mode
   unreachable while intervention is required.
 - Preserve the non-reachability flag guard when adding ancillary flag handling.
+- Preserve the WWAN reachability flag matrix when changing cellular handling.
 - Review changes touching network requests, sockets, telemetry, or service endpoints; examples from the scan include NetworkState/Info.plist, NetworkStateTests/Info.plist.
 - Review changes touching file, media, JSON, XML, CSV, OCR, or data parsing; examples from the scan include NetworkState/Info.plist, NetworkStateTests/Info.plist.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -40,6 +40,8 @@ Helpful reports include:
   combined automatic modes with user intervention required.
 - The non-reachability flag guard should ensure ancillary route flags cannot
   report connectivity without the `Reachable` bit.
+- The WWAN reachability flag matrix should keep the cellular bit dependent on
+  `Reachable` without rejecting valid reachable cellular routes.
 - Review found network clients, sockets, web APIs, or service endpoints; changes in those areas should receive security-focused review before merge.
 - Review found file, document, data, or media parsing flows; changes in those areas should receive security-focused review before merge.
 - CocoaPods metadata lives in `NetworkState.podspec`. Run `make lint`,

--- a/VISION.md
+++ b/VISION.md
@@ -26,6 +26,7 @@ Priority:
 - Keep the intervention-required flag from reporting connectivity
 - Keep the automatic intervention matrix across every automatic connection mode
 - Keep the non-reachability flag guard around ancillary route flags
+- Keep the WWAN reachability flag matrix around cellular routes
 - Avoid growing the library beyond focused reachability utilities
 - Keep `SystemConfiguration` checks local to the device
 - Keep simulator verification independent of local signing identities by
@@ -67,6 +68,7 @@ Contribution rules:
 - Preserve combined automatic connection flags coverage when changing flag logic.
 - Preserve intervention-required flag handling when changing reachability logic.
 - Preserve the non-reachability flag guard when changing ancillary flag logic.
+- Preserve the WWAN reachability flag matrix when changing cellular flag logic.
 - Preserve deployment target alignment when changing package metadata.
 - Preserve framework version alignment when changing release metadata.
 - Preserve the shared framework scheme when changing Xcode project metadata.

--- a/docs/plans/2026-06-15-wwan-reachability-flag-matrix.md
+++ b/docs/plans/2026-06-15-wwan-reachability-flag-matrix.md
@@ -1,6 +1,6 @@
 # WWAN Reachability Flag Matrix
 
-status: in progress
+status: completed
 
 ## Problem
 
@@ -40,3 +40,25 @@ valid reachable cellular route without a focused regression.
 - This remains a local SystemConfiguration flag snapshot, not proof of internet
   access or availability of any remote service.
 - The stacked base pull request must remain available and merge first.
+
+## Work Completed
+
+- Added a focused XCTest fixture for `kSCNetworkFlagsIsWWAN` with and without
+  the required `Reachable` bit.
+- Preserved the production predicate and all existing automatic, intervention,
+  and ancillary flag fixtures.
+- Added exact portable contracts and synchronized maintenance guidance.
+
+## Verification Completed
+
+- All four Make gates passed from the repository and the canonical check passed
+  from an external directory through the absolute Makefile path.
+- The baseline checker compiled and passed; local Linux reported the existing
+  `xcodebuild` limitation and completed the static iOS baseline.
+- Six isolated hostile mutations were rejected: missing WWAN constant, missing
+  unreachable assertion, missing reachable assertion, inverted reachability,
+  missing guidance, and stale plan status.
+- `git diff --check`, exact intended-path, generated-artifact,
+  credential-pattern, Xcode project, conflict-marker, binary, and large-file
+  audits passed.
+- No live network request, remote probe, simulator, or device was used.

--- a/docs/plans/2026-06-15-wwan-reachability-flag-matrix.md
+++ b/docs/plans/2026-06-15-wwan-reachability-flag-matrix.md
@@ -1,0 +1,42 @@
+# WWAN Reachability Flag Matrix
+
+status: in progress
+
+## Problem
+
+The fixture matrix proves transient, local-address, and direct-route flags
+cannot create connectivity, but it omits the iOS-specific
+`kSCNetworkFlagsIsWWAN` bit. Cellular reachability commonly includes that flag,
+so a predicate refactor could accidentally treat WWAN as sufficient or reject a
+valid reachable cellular route without a focused regression.
+
+## Scope
+
+- Prove WWAN alone remains unreachable.
+- Prove `Reachable | IsWWAN` remains reachable.
+- Preserve the production predicate, public API, automatic-connection matrix,
+  deployment target, framework metadata, and package support.
+- Add mutation-sensitive static contracts and synchronized guidance.
+
+## Implementation
+
+1. Add a focused XCTest fixture for WWAN with and without `Reachable`.
+2. Require both assertions and the iOS flag constant in the portable checker.
+3. Record the cellular flag matrix in project maintenance documentation.
+
+## Verification
+
+- Run checker compilation and every Make gate from the repository plus the
+  canonical gate from an external directory with explicit timeouts.
+- Reject isolated mutations that remove the WWAN constant, remove either
+  assertion, invert an assertion, remove guidance, or leave the plan incomplete.
+- Audit the exact diff, generated artifacts, credential patterns, Xcode project
+  integrity, conflict markers, binaries, large files, and intended paths.
+
+## Risks
+
+- Xcode and XCTest execution require a compatible macOS toolchain; Linux can
+  validate only the dependency-free source contract.
+- This remains a local SystemConfiguration flag snapshot, not proof of internet
+  access or availability of any remote service.
+- The stacked base pull request must remain available and merge first.

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -128,6 +128,16 @@ def main() -> int:
         or "kSCNetworkFlagsIsDirect" not in tests
     ):
         failures.append("tests must cover ancillary flags with and without the Reachable flag")
+    wwan_test = tests.split("func testWWANFlagRequiresReachableBaseFlag()", 1)[-1].split("\n    func ", 1)[0]
+    if (
+        "func testWWANFlagRequiresReachableBaseFlag()" not in tests
+        or "kSCNetworkFlagsIsWWAN" not in wwan_test
+        or "XCTAssertFalse(NetworkState.isReachableWithFlags(SCNetworkReachabilityFlags(rawValue: wwan)))" not in wwan_test
+        or "XCTAssertTrue(NetworkState.isReachableWithFlags(SCNetworkReachabilityFlags(rawValue: reachable | wwan)))" not in wwan_test
+        or wwan_test.count("XCTAssertFalse") != 1
+        or wwan_test.count("XCTAssertTrue") != 1
+    ):
+        failures.append("tests must cover WWAN reachability with and without the Reachable flag")
     if "testExample" in tests or "testPerformanceExample" in tests:
         failures.append("placeholder XCTest methods must be replaced")
 
@@ -227,6 +237,9 @@ def main() -> int:
     ]:
         if phrase not in docs:
             failures.append(f"docs must mention {phrase}")
+    for relative_path in ["README.md", "SECURITY.md", "VISION.md", "CHANGES.md"]:
+        if "wwan reachability flag matrix" not in read(relative_path).lower():
+            failures.append(f"{relative_path} must document the WWAN reachability flag matrix")
 
     readme = " ".join(read("README.md").split())
     for phrase in [
@@ -310,6 +323,14 @@ def main() -> int:
     automatic_intervention_plan = read("docs/plans/2026-06-12-automatic-intervention-matrix.md")
     if "status: completed" not in automatic_intervention_plan or "hostile mutations" not in automatic_intervention_plan:
         failures.append("automatic intervention matrix plan must record completed verification")
+    wwan_plan = read("docs/plans/2026-06-15-wwan-reachability-flag-matrix.md")
+    if (
+        "status: completed" not in wwan_plan
+        or "All four Make gates passed" not in wwan_plan
+        or "Six isolated hostile mutations were rejected" not in wwan_plan
+        or "external directory" not in wwan_plan
+    ):
+        failures.append("WWAN reachability flag matrix plan must record completed verification")
 
     hosted_plan = read("docs/plans/2026-06-10-hosted-project-validation.md")
     workflow = read(".github/workflows/check.yml")


### PR DESCRIPTION
## Summary
Add focused coverage for the iOS WWAN flag with and without the required `Reachable` bit.

## Baseline
The ancillary flag matrix covers transient, local-address, and direct-route bits, but omits `kSCNetworkFlagsIsWWAN`, which commonly accompanies cellular reachability.

## Improvements
- prove WWAN alone cannot create connectivity
- prove `Reachable | IsWWAN` remains reachable
- add mutation-sensitive static contracts and completed plan evidence
- preserve the production predicate, public API, project metadata, and podspec

## Validation
- `python3 -m py_compile scripts/check-baseline.py`
- `make lint`, `make test`, `make build`, and `make check`
- external-directory absolute-Makefile `make check`
- six isolated hostile mutations rejected
- exact-path, artifact, credential, Xcode project, conflict-marker, binary, and large-file audits

## Risk
`xcodebuild` is unavailable on the Linux validation host, so local evidence is the dependency-free static contract. Hosted macOS validation parses the project and runs the canonical baseline without remote probes.

## Follow-Ups
This PR is stacked on #9 and must retain base-first merge order. Do not merge or close either PR without explicit authorization.
