### PR TITLE
test: cover reachability decision truth table

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 
 - Added a WWAN reachability flag matrix covering the cellular bit with and
   without the required `Reachable` flag.
+- Added a reachability decision truth table covering all 16 combinations of the
+  four flags that control the public evaluator.
 
 ## 2026-06-13
 

--- a/NetworkStateTests/NetworkStateTests.swift
+++ b/NetworkStateTests/NetworkStateTests.swift
@@ -95,4 +95,41 @@ class NetworkStateTests: XCTestCase {
         XCTAssertTrue(NetworkState.isReachableWithFlags(SCNetworkReachabilityFlags(rawValue: reachable | wwan)))
     }
 
+    func testReachabilityDecisionTruthTable() {
+        let booleanValues = [false, true]
+        var coveredRows = 0
+
+        for isReachable in booleanValues {
+            for connectionRequired in booleanValues {
+                for canConnectAutomatically in booleanValues {
+                    for interventionRequired in booleanValues {
+                        var rawValue: UInt32 = 0
+                        if isReachable {
+                            rawValue |= UInt32(kSCNetworkFlagsReachable)
+                        }
+                        if connectionRequired {
+                            rawValue |= UInt32(kSCNetworkFlagsConnectionRequired)
+                        }
+                        if canConnectAutomatically {
+                            rawValue |= UInt32(kSCNetworkFlagsConnectionOnDemand)
+                        }
+                        if interventionRequired {
+                            rawValue |= UInt32(kSCNetworkFlagsInterventionRequired)
+                        }
+
+                        let expected = isReachable && !interventionRequired &&
+                            (!connectionRequired || canConnectAutomatically)
+                        XCTAssertEqual(
+                            NetworkState.isReachableWithFlags(SCNetworkReachabilityFlags(rawValue: rawValue)),
+                            expected
+                        )
+                        coveredRows += 1
+                    }
+                }
+            }
+        }
+
+        XCTAssertEqual(coveredRows, 16)
+    }
+
 }

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
   bits cannot create connectivity without the `Reachable` flag.
 - The WWAN reachability flag matrix verifies the cellular bit cannot create
   connectivity alone and remains accepted with `Reachable`.
+- The reachability decision truth table covers every combination of reachable,
+  connection-required, automatic-connect, and intervention-required state.
 - Open `NetworkState.xcodeproj` in Xcode and run the `NetworkStateTests` scheme.
 - The Make gates are location-independent. From another directory, pass the
   checkout's Makefile by absolute path, such as
@@ -142,6 +144,7 @@ When the required SDK or runtime is unavailable, use static checks and source re
   unreachable while intervention is required.
 - Preserve the non-reachability flag guard when adding ancillary flag handling.
 - Preserve the WWAN reachability flag matrix when changing cellular handling.
+- Preserve the reachability decision truth table when changing flag logic.
 - Review changes touching network requests, sockets, telemetry, or service endpoints; examples from the scan include NetworkState/Info.plist, NetworkStateTests/Info.plist.
 - Review changes touching file, media, JSON, XML, CSV, OCR, or data parsing; examples from the scan include NetworkState/Info.plist, NetworkStateTests/Info.plist.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -42,6 +42,8 @@ Helpful reports include:
   report connectivity without the `Reachable` bit.
 - The WWAN reachability flag matrix should keep the cellular bit dependent on
   `Reachable` without rejecting valid reachable cellular routes.
+- The reachability decision truth table should cover every boolean combination
+  that controls the public flag evaluator.
 - Review found network clients, sockets, web APIs, or service endpoints; changes in those areas should receive security-focused review before merge.
 - Review found file, document, data, or media parsing flows; changes in those areas should receive security-focused review before merge.
 - CocoaPods metadata lives in `NetworkState.podspec`. Run `make lint`,

--- a/VISION.md
+++ b/VISION.md
@@ -27,6 +27,7 @@ Priority:
 - Keep the automatic intervention matrix across every automatic connection mode
 - Keep the non-reachability flag guard around ancillary route flags
 - Keep the WWAN reachability flag matrix around cellular routes
+- Keep the reachability decision truth table exhaustive across decision flags
 - Avoid growing the library beyond focused reachability utilities
 - Keep `SystemConfiguration` checks local to the device
 - Keep simulator verification independent of local signing identities by

--- a/docs/plans/2026-06-15-reachability-decision-truth-table.md
+++ b/docs/plans/2026-06-15-reachability-decision-truth-table.md
@@ -1,6 +1,6 @@
 # Reachability Decision Truth Table
 
-Status: planned
+Status: completed
 
 ## Problem
 
@@ -60,3 +60,24 @@ the named examples while regressing an uncovered combination.
 - Existing focused flag fixtures remain intact and continue to pass the portable
   checker.
 - No production, dependency, project, or workflow file changes are introduced.
+
+## Work Completed
+
+- Added a nested four-dimension XCTest matrix that constructs concrete
+  reachability flags and checks all 16 combinations against the documented
+  decision rule.
+- Retained every existing focused fixture and left production code unchanged.
+- Added mutation-sensitive portable contracts and synchronized guidance.
+
+## Verification Completed
+
+- All four Make gates passed from the repository and `make check` passed from
+  an external directory.
+- Seven isolated hostile mutations were rejected for incomplete dimensions,
+  missing flag inputs, incorrect expected logic, weakened row count, missing
+  guidance, and stale plan status.
+- The exact seven-file implementation diff passed project/dependency,
+  generated-artifact, credential, conflict, binary, large-file, mode,
+  whitespace, and intended-path audits.
+- `xcodebuild` and XCTest were unavailable on Linux; the portable static iOS
+  baseline passed and no local runtime claim was made.

--- a/docs/plans/2026-06-15-reachability-decision-truth-table.md
+++ b/docs/plans/2026-06-15-reachability-decision-truth-table.md
@@ -1,0 +1,62 @@
+# Reachability Decision Truth Table
+
+Status: planned
+
+## Problem
+
+`NetworkState.isReachableWithFlags(_:)` derives its result from four decision
+bits: `Reachable`, `ConnectionRequired`, either automatic-connection flag, and
+`InterventionRequired`. Existing fixtures cover important examples, but they do
+not prove every boolean combination. A future predicate change could preserve
+the named examples while regressing an uncovered combination.
+
+## Scope
+
+- Add an XCTest truth table covering all 16 combinations of the four decision
+  dimensions.
+- Derive concrete `SCNetworkReachabilityFlags` inputs for each row while using a
+  stable representative automatic flag.
+- Assert the production decision rule: connectivity requires `Reachable`, must
+  not require intervention, and when a connection is required it must be able
+  to connect automatically.
+- Keep the current production predicate, public API, deployment targets,
+  dependencies, project structure, and existing focused fixtures unchanged.
+- Add mutation-sensitive portable contracts and synchronized guidance.
+
+## Files
+
+- `NetworkStateTests/NetworkStateTests.swift`
+- `scripts/check-baseline.py`
+- `README.md`
+- `SECURITY.md`
+- `VISION.md`
+- `CHANGES.md`
+- `docs/plans/2026-06-15-reachability-decision-truth-table.md`
+
+## Verification
+
+- Run the portable static iOS baseline through all standard Make aliases and
+  from an external directory.
+- On this Linux host, truthfully report Xcode/XCTest availability rather than
+  claiming runtime execution.
+- Reject isolated mutations for incomplete row coverage, incorrect expected
+  logic, missing decision inputs, missing guidance, and stale plan status.
+- Audit the exact diff, project/dependency drift, generated artifacts,
+  credentials, conflicts, binaries, large files, modes, and whitespace.
+
+## Risks
+
+- Linux cannot execute the XCTest target; hosted macOS remains the runtime
+  validation boundary.
+- The truth table characterizes the existing synchronous default-route
+  predicate and does not claim internet or service availability.
+- This change must remain stacked on PR #10; neither pull request may be merged
+  or closed without explicit owner authorization.
+
+## Success Criteria
+
+- Every combination of the four decision dimensions is represented exactly
+  once and checked against the documented boolean rule.
+- Existing focused flag fixtures remain intact and continue to pass the portable
+  checker.
+- No production, dependency, project, or workflow file changes are introduced.

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -57,6 +57,8 @@ REQUIRED = [
     "docs/plans/2026-06-12-checkout-credential-boundary.md",
     "docs/plans/2026-06-13-platform-network-assumptions.md",
     "docs/plans/2026-06-13-location-independent-make.md",
+    "docs/plans/2026-06-15-reachability-decision-truth-table.md",
+    "docs/plans/2026-06-15-wwan-reachability-flag-matrix.md",
     "docs/readme-overview.svg",
 ]
 
@@ -138,6 +140,24 @@ def main() -> int:
         or wwan_test.count("XCTAssertTrue") != 1
     ):
         failures.append("tests must cover WWAN reachability with and without the Reachable flag")
+    truth_table_test = tests.split("func testReachabilityDecisionTruthTable()", 1)[-1].split("\n    func ", 1)[0]
+    if (
+        "func testReachabilityDecisionTruthTable()" not in tests
+        or "let booleanValues = [false, true]" not in truth_table_test
+        or truth_table_test.count("for ") != 4
+        or "for isReachable in booleanValues" not in truth_table_test
+        or "for connectionRequired in booleanValues" not in truth_table_test
+        or "for canConnectAutomatically in booleanValues" not in truth_table_test
+        or "for interventionRequired in booleanValues" not in truth_table_test
+        or "kSCNetworkFlagsReachable" not in truth_table_test
+        or "kSCNetworkFlagsConnectionRequired" not in truth_table_test
+        or "kSCNetworkFlagsConnectionOnDemand" not in truth_table_test
+        or "kSCNetworkFlagsInterventionRequired" not in truth_table_test
+        or "let expected = isReachable && !interventionRequired &&" not in truth_table_test
+        or "(!connectionRequired || canConnectAutomatically)" not in truth_table_test
+        or "XCTAssertEqual(coveredRows, 16)" not in truth_table_test
+    ):
+        failures.append("tests must cover the complete reachability decision truth table")
     if "testExample" in tests or "testPerformanceExample" in tests:
         failures.append("placeholder XCTest methods must be replaced")
 
@@ -240,6 +260,8 @@ def main() -> int:
     for relative_path in ["README.md", "SECURITY.md", "VISION.md", "CHANGES.md"]:
         if "wwan reachability flag matrix" not in read(relative_path).lower():
             failures.append(f"{relative_path} must document the WWAN reachability flag matrix")
+        if "reachability decision truth table" not in read(relative_path).lower():
+            failures.append(f"{relative_path} must document the reachability decision truth table")
 
     readme = " ".join(read("README.md").split())
     for phrase in [
@@ -331,6 +353,15 @@ def main() -> int:
         or "external directory" not in wwan_plan
     ):
         failures.append("WWAN reachability flag matrix plan must record completed verification")
+    truth_table_plan = read("docs/plans/2026-06-15-reachability-decision-truth-table.md")
+    if (
+        "status: completed" not in truth_table_plan.lower()
+        or "All four Make gates passed" not in truth_table_plan
+        or "Seven isolated hostile mutations were rejected" not in truth_table_plan
+        or "external directory" not in truth_table_plan
+        or re.search(r"(?i)\b(?:pending|todo|tbd|not run)\b", truth_table_plan)
+    ):
+        failures.append("reachability decision truth table plan must record completed verification")
 
     hosted_plan = read("docs/plans/2026-06-10-hosted-project-validation.md")
     workflow = read(".github/workflows/check.yml")


### PR DESCRIPTION
## Summary

The reachability evaluator now has exhaustive regression coverage across every combination of its four decision dimensions. This closes the gaps between the existing focused fixtures, so a predicate change cannot preserve a few named examples while silently changing another reachable, connection-required, automatic-connect, or intervention-required state.

## Baseline

This PR stacks on garethpaul/NetworkState#10.

## Improvements

The production API and predicate remain unchanged. The new matrix checks all 16 rows against the documented rule, while the portable baseline makes incomplete dimensions, incorrect expectations, or weakened row coverage fail closed.

## Validation

- `make lint`, `make test`, `make build`, and `make check`
- External-directory absolute-Makefile `make check`
- Seven isolated hostile mutations rejected
- Exact diff, project/dependency, artifact, credential, binary, mode, large-file, conflict, and whitespace audits
- Plan-aware review: no actionable findings (`/tmp/compound-engineering/ce-code-review/20260615T172845Z-networkstate-truth-table`)

## Risk

`xcodebuild` and XCTest are unavailable on Linux; hosted macOS remains the runtime validation boundary.

## Follow-Ups

No runtime or deployment behavior changes. The hosted push and pull-request baselines should execute the existing XCTest target and portable checker on the exact PR head.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5.5-000000)
