### PR TITLE
Scope intervention to required connections

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@
   without the required `Reachable` flag.
 - Added a reachability decision truth table covering all 16 combinations of the
   four flags that control the public evaluator.
+- Scoped intervention-required handling to connections that must first be
+  established, preserving already reachable routes that need no connection.
 
 ## 2026-06-13
 

--- a/NetworkState/NetworkState.swift
+++ b/NetworkState/NetworkState.swift
@@ -37,6 +37,6 @@ public class NetworkState {
         let interventionRequired = (flags.rawValue & UInt32(kSCNetworkFlagsInterventionRequired)) != 0
         let canConnectWithoutUserInteraction = canConnectAutomatically && !interventionRequired
 
-        return isReachable && !interventionRequired && (!needsConnection || canConnectWithoutUserInteraction)
+        return isReachable && (!needsConnection || canConnectWithoutUserInteraction)
     }
 }

--- a/NetworkStateTests/NetworkStateTests.swift
+++ b/NetworkStateTests/NetworkStateTests.swift
@@ -56,11 +56,11 @@ class NetworkStateTests: XCTestCase {
         XCTAssertTrue(NetworkState.isReachableWithFlags(SCNetworkReachabilityFlags(rawValue: reachable | connectionRequired | connectionOnDemand | connectionOnTraffic)))
     }
 
-    func testInterventionRequiredFlagPreventsReachability() {
+    func testInterventionRequiredDoesNotBlockEstablishedReachability() {
         let reachable = UInt32(kSCNetworkFlagsReachable)
         let interventionRequired = UInt32(kSCNetworkFlagsInterventionRequired)
 
-        XCTAssertFalse(NetworkState.isReachableWithFlags(SCNetworkReachabilityFlags(rawValue: reachable | interventionRequired)))
+        XCTAssertTrue(NetworkState.isReachableWithFlags(SCNetworkReachabilityFlags(rawValue: reachable | interventionRequired)))
     }
 
     func testAutomaticConnectionModesRequireNoUserIntervention() {
@@ -117,8 +117,8 @@ class NetworkStateTests: XCTestCase {
                             rawValue |= UInt32(kSCNetworkFlagsInterventionRequired)
                         }
 
-                        let expected = isReachable && !interventionRequired &&
-                            (!connectionRequired || canConnectAutomatically)
+                        let expected = isReachable &&
+                            (!connectionRequired || (canConnectAutomatically && !interventionRequired))
                         XCTAssertEqual(
                             NetworkState.isReachableWithFlags(SCNetworkReachabilityFlags(rawValue: rawValue)),
                             expected

--- a/README.md
+++ b/README.md
@@ -62,8 +62,9 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
 - Automatic connection handling still requires the reachable flag, so connection-on-demand flags alone do not report connectivity.
 - Combined automatic connection flags remain reachable when the base reachable
   flag is present and no user intervention is required.
-- The intervention-required flag prevents reachability even when the base
-  reachable flag is present.
+- The intervention-required flag prevents an automatic required connection
+  from being treated as reachable, but does not invalidate a route that is
+  already reachable without establishing a connection.
 - The automatic intervention matrix covers on-demand, on-traffic, and combined
   automatic modes so none report connectivity while user action is required.
 - The non-reachability flag guard verifies transient, local-address, and direct

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -35,7 +35,8 @@ Helpful reports include:
 - Combined automatic connection flags should stay covered so on-demand and
   on-traffic states remain accepted together when reachable.
 - The intervention-required flag should prevent connectivity from being
-  reported when the network state still needs user action.
+  reported only when a required connection still needs user action; it should
+  not override an already established reachable route.
 - The automatic intervention matrix should cover on-demand, on-traffic, and
   combined automatic modes with user intervention required.
 - The non-reachability flag guard should ensure ancillary route flags cannot

--- a/VISION.md
+++ b/VISION.md
@@ -23,7 +23,8 @@ Priority:
 - Keep automatic connection reachability flags covered without live network state
 - Keep automatic connection behavior constrained so it requires the reachable flag
 - Keep combined automatic connection flags covered in fixture tests
-- Keep the intervention-required flag from reporting connectivity
+- Keep intervention-required handling scoped to connections that must first be
+  established
 - Keep the automatic intervention matrix across every automatic connection mode
 - Keep the non-reachability flag guard around ancillary route flags
 - Keep the WWAN reachability flag matrix around cellular routes

--- a/docs/plans/2026-06-15-intervention-required-scope.md
+++ b/docs/plans/2026-06-15-intervention-required-scope.md
@@ -1,6 +1,6 @@
 # Intervention-Required Scope
 
-Status: planned
+Status: completed
 
 ## Problem
 
@@ -66,3 +66,25 @@ expected-value expression, so it cannot detect this boundary error.
 - A required connection remains unreachable when manual intervention is needed.
 - The exhaustive truth table and focused fixtures independently enforce both
   sides of that boundary.
+
+## Work Completed
+
+- Scoped the production intervention check to automatic connections that must
+  first be established.
+- Corrected the exhaustive truth-table oracle and added a focused established-
+  route fixture that rejects the previous global veto.
+- Strengthened the portable checker and synchronized user, security, vision,
+  and changelog guidance.
+
+## Verification Completed
+
+- All four Make gates passed from the repository and `make check` passed from
+  an external directory.
+- Six isolated hostile mutations were rejected for restoring the global veto,
+  weakening the focused fixture, weakening the truth-table oracle, removing
+  guidance, and reopening the plan status.
+- The exact eight-file implementation diff passed project/dependency,
+  generated-artifact, credential, conflict, binary, large-file, mode,
+  whitespace, and intended-path audits.
+- `xcodebuild` and XCTest were unavailable on Linux; the portable static iOS
+  baseline passed and no local runtime claim was made.

--- a/docs/plans/2026-06-15-intervention-required-scope.md
+++ b/docs/plans/2026-06-15-intervention-required-scope.md
@@ -1,0 +1,68 @@
+# Intervention-Required Scope
+
+Status: planned
+
+## Problem
+
+`NetworkState.isReachableWithFlags(_:)` currently treats
+`InterventionRequired` as a global connectivity veto. Apple documents that flag
+as describing manual action needed to establish a connection, alongside
+`ConnectionRequired`. A route that is already reachable without establishing a
+connection should therefore remain reachable even if a synthetic flag fixture
+also contains `InterventionRequired`.
+
+The exhaustive truth table currently repeats the production mistake in its
+expected-value expression, so it cannot detect this boundary error.
+
+## Scope
+
+- Apply `InterventionRequired` only while evaluating an automatically
+  established connection that is actually required.
+- Correct the 16-row truth-table oracle independently of the production
+  expression.
+- Add a focused fixture for `Reachable | InterventionRequired` without
+  `ConnectionRequired`.
+- Strengthen the portable checker and synchronize user and maintainer guidance.
+- Keep the public API, deployment targets, dependencies, project structure, and
+  workflows unchanged.
+
+## Files
+
+- `NetworkState/NetworkState.swift`
+- `NetworkStateTests/NetworkStateTests.swift`
+- `scripts/check-baseline.py`
+- `README.md`
+- `SECURITY.md`
+- `VISION.md`
+- `CHANGES.md`
+- `docs/plans/2026-06-15-intervention-required-scope.md`
+
+## Verification
+
+- Run every standard Make alias and invoke the absolute Makefile from an
+  external directory.
+- On Linux, report Xcode/XCTest unavailability rather than claiming runtime
+  execution.
+- Reject isolated mutations that restore the global intervention veto, weaken
+  the focused fixture or truth-table oracle, remove guidance, or reopen the
+  completed plan.
+- Audit the exact diff, generated artifacts, credentials, conflicts, binaries,
+  large files, modes, whitespace, and project/dependency drift.
+
+## Risks
+
+- Linux cannot execute XCTest; hosted macOS remains the runtime validation
+  boundary.
+- The corrected case is an unusual synthetic flag combination, but accepting it
+  follows the documented relationship between connection-required and
+  intervention-required state.
+- This change must remain stacked on PR #11, and no pull request may be merged
+  or closed without explicit owner authorization.
+
+## Success Criteria
+
+- `Reachable | InterventionRequired` remains reachable when no connection must
+  first be established.
+- A required connection remains unreachable when manual intervention is needed.
+- The exhaustive truth table and focused fixtures independently enforce both
+  sides of that boundary.

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -94,8 +94,10 @@ def main() -> int:
             failures.append(f"reachability flag evaluation must handle {phrase}")
     if "return isReachable &&" not in swift:
         failures.append("automatic reachability handling must still require the reachable flag")
-    if "return isReachable && !interventionRequired" not in swift:
-        failures.append("reachability evaluation must reject intervention-required states")
+    if "return isReachable && (!needsConnection || canConnectWithoutUserInteraction)" not in swift:
+        failures.append("reachability evaluation must scope intervention to required connections")
+    if "return isReachable && !interventionRequired" in swift:
+        failures.append("reachability evaluation must not apply intervention as a global veto")
     if "(flags.rawValue & UInt32(kSCNetworkFlagsReachable)) != 0" not in swift:
         failures.append("reachability evaluation must derive connectivity from the Reachable flag")
 
@@ -112,8 +114,14 @@ def main() -> int:
         failures.append("tests must cover automatic connection flags without the reachable flag")
     if "testCombinedAutomaticConnectionFlagsAreReachable" not in tests:
         failures.append("tests must cover combined automatic connection reachability flags")
-    if "testInterventionRequiredFlagPreventsReachability" not in tests:
-        failures.append("tests must cover intervention-required reachability flags")
+    established_intervention_test = tests.split("func testInterventionRequiredDoesNotBlockEstablishedReachability()", 1)[-1].split("\n    func ", 1)[0]
+    if (
+        "func testInterventionRequiredDoesNotBlockEstablishedReachability()" not in tests
+        or "reachable | interventionRequired" not in established_intervention_test
+        or established_intervention_test.count("XCTAssertTrue") != 1
+        or "XCTAssertFalse" in established_intervention_test
+    ):
+        failures.append("tests must keep established reachability independent of intervention state")
     automatic_intervention_test = tests.split("func testAutomaticConnectionModesRequireNoUserIntervention()", 1)[-1].split("func testNonReachabilityFlagsDoNotCreateConnectivity()", 1)[0]
     if (
         "func testAutomaticConnectionModesRequireNoUserIntervention()" not in tests
@@ -153,8 +161,8 @@ def main() -> int:
         or "kSCNetworkFlagsConnectionRequired" not in truth_table_test
         or "kSCNetworkFlagsConnectionOnDemand" not in truth_table_test
         or "kSCNetworkFlagsInterventionRequired" not in truth_table_test
-        or "let expected = isReachable && !interventionRequired &&" not in truth_table_test
-        or "(!connectionRequired || canConnectAutomatically)" not in truth_table_test
+        or "let expected = isReachable &&" not in truth_table_test
+        or "(!connectionRequired || (canConnectAutomatically && !interventionRequired))" not in truth_table_test
         or "XCTAssertEqual(coveredRows, 16)" not in truth_table_test
     ):
         failures.append("tests must cover the complete reachability decision truth table")
@@ -262,6 +270,15 @@ def main() -> int:
             failures.append(f"{relative_path} must document the WWAN reachability flag matrix")
         if "reachability decision truth table" not in read(relative_path).lower():
             failures.append(f"{relative_path} must document the reachability decision truth table")
+    intervention_scope_guidance = {
+        "README.md": "does not invalidate a route that is already reachable",
+        "SECURITY.md": "only when a required connection still needs user action",
+        "VISION.md": "scoped to connections that must first be established",
+        "CHANGES.md": "preserving already reachable routes that need no connection",
+    }
+    for relative_path, phrase in intervention_scope_guidance.items():
+        if phrase not in " ".join(read(relative_path).split()):
+            failures.append(f"{relative_path} must document intervention-required scope")
 
     readme = " ".join(read("README.md").split())
     for phrase in [
@@ -362,6 +379,15 @@ def main() -> int:
         or re.search(r"(?i)\b(?:pending|todo|tbd|not run)\b", truth_table_plan)
     ):
         failures.append("reachability decision truth table plan must record completed verification")
+    intervention_scope_plan = read("docs/plans/2026-06-15-intervention-required-scope.md")
+    if (
+        "status: completed" not in intervention_scope_plan.lower()
+        or "All four Make gates passed" not in intervention_scope_plan
+        or "Six isolated hostile mutations were rejected" not in intervention_scope_plan
+        or "external directory" not in intervention_scope_plan
+        or re.search(r"(?i)\b(?:pending|todo|tbd|not run)\b", intervention_scope_plan)
+    ):
+        failures.append("intervention-required scope plan must record completed verification")
 
     hosted_plan = read("docs/plans/2026-06-10-hosted-project-validation.md")
     workflow = read(".github/workflows/check.yml")


### PR DESCRIPTION
## Summary

- scope `InterventionRequired` to connections that must first be established
- correct the exhaustive 16-row truth-table oracle and add a focused established-route fixture
- enforce the boundary in the portable checker and synchronize project guidance

Apple documents `ConnectionRequired` as the state where a connection must first be established, with `InterventionRequired` indicating manual action in that context: https://developer.apple.com/documentation/systemconfiguration/scnetworkreachabilityflags/connectionrequired

## Baseline

The reachability predicate previously treated `InterventionRequired` as a global veto, including routes that were already established and did not require a connection to be created first.

## Improvements

- Scope `InterventionRequired` to connections that also require establishment.
- Correct the exhaustive 16-row truth-table oracle.
- Add a focused established-route fixture and synchronized portable contracts.

## Validation

- `make lint`
- `make test`
- `make build`
- `make check`
- external-directory absolute-Makefile `make check`
- six isolated hostile mutations rejected
- exact diff, artifact, credential, conflict, binary, large-file, mode, whitespace, project, dependency, and workflow audits passed
- one bounded exact-head GitHub read found both hosted checks successful

## Risk

- Xcode/XCTest is unavailable on this Linux host; hosted macOS remains the runtime validation boundary.
- The library remains a synchronous local IPv4 default-route snapshot and does not prove internet or service availability.

## Follow-Ups

- This PR is stacked on #11 and must be merged after its base.
- Do not merge or close either PR without explicit owner authorization.
