### PR TITLE
Land reviewed NetworkState reachability stack

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @garethpaul

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,4 +14,6 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
       - run: make check

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -17,3 +17,4 @@ jobs:
         with:
           persist-credentials: false
       - run: make check
+      - run: ./build.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,30 @@
+# NetworkState Contributor Guide
+
+## Scope
+
+This repository maintains a small Swift wrapper around legacy
+`SCNetworkReachability` flag snapshots.
+
+## Verification
+
+- Run `make check` for dependency-free repository contracts.
+- Run `./build.sh` on macOS to compile and execute the XCTest truth table.
+- Override `DESTINATION`, `SWIFT_VERSION`, or `IPHONEOS_DEPLOYMENT_TARGET` when
+  validating with a different installed Xcode toolchain.
+
+## Reachability Rules
+
+- Require the `Reachable` flag for every positive result.
+- Treat `ConnectionRequired` as unavailable unless on-demand or on-traffic can
+  establish the connection without user intervention.
+- Do not let transient, local, direct, or WWAN flags create reachability alone.
+- Guard WWAN-only constants to iOS-family builds.
+- Describe results as local route reachability, never proof of internet or
+  service availability.
+
+## Maintenance
+
+- Preserve the public Boolean API and fixture evaluator unless a reviewed
+  compatibility change explicitly replaces them.
+- Keep checkout credentials disabled and the single hosted workflow intact.
+- Record skipped device, carrier, captive-portal, and live-service validation.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@
   without the required `Reachable` flag.
 - Added a reachability decision truth table covering all 16 combinations of the
   four flags that control the public evaluator.
+- Scoped intervention-required handling to connections that must first be
+  established, preserving already reachable routes that need no connection.
 
 ## 2026-06-13
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 
 - Added a WWAN reachability flag matrix covering the cellular bit with and
   without the required `Reachable` flag.
+- Added a reachability decision truth table covering all 16 combinations of the
+  four flags that control the public evaluator.
 
 ## 2026-06-13
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## 2026-06-15
+
+- Added a WWAN reachability flag matrix covering the cellular bit with and
+  without the required `Reachable` flag.
+
 ## 2026-06-13
 
 - Made every SDK-free Make alias resolve the static checker from the checkout

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## 2026-06-12
+
+- Disabled persisted checkout credentials and enforced the sole pinned
+  credential-free workflow boundary.
+
 ## 2026-06-10
 
 - Added an automatic intervention matrix covering on-demand, on-traffic, and

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # Changes
 
+## 2026-06-13
+
+- Documented the synchronous IPv4 default-route reachability semantics, the
+  request-level failures callers must still handle, the legacy iOS 8.0
+  compatibility boundary, and CocoaPods-only package support.
+- Enforced the local-only, no-remote-probe documentation contract in the static
+  baseline.
+
 ## 2026-06-12
 
 - Disabled persisted checkout credentials and enforced the sole pinned

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,11 +1,19 @@
 # Changes
 
+## 2026-06-19
+
+- Made the reachability truth table executable on current Xcode while retaining
+  the legacy Boolean API and iOS 8 package declaration.
+- Expanded automatic-mode coverage to distinguish on-demand, on-traffic, and
+  combined flags across all 32 core decision rows.
+- Added repository ownership guidance and a credential-free hosted native gate.
+
 ## 2026-06-15
 
 - Added a WWAN reachability flag matrix covering the cellular bit with and
   without the required `Reachable` flag.
-- Added a reachability decision truth table covering all 16 combinations of the
-  four flags that control the public evaluator.
+- Added a reachability decision truth table for the flags that control the
+  public evaluator.
 - Scoped intervention-required handling to connections that must first be
   established, preserving already reachable routes that need no connection.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## 2026-06-13
 
+- Made every SDK-free Make alias resolve the static checker from the checkout
+  when the Makefile is invoked by absolute path.
 - Documented the synchronous IPv4 default-route reachability semantics, the
   request-level failures callers must still handle, the legacy iOS 8.0
   compatibility boundary, and CocoaPods-only package support.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## 2026-06-10
 
+- Added an automatic intervention matrix covering on-demand, on-traffic, and
+  combined automatic connection flags while user action is required.
 - Added a non-reachability flag guard covering transient, local-address, and
   direct-route bits with and without the `Reachable` flag.
 - Added pinned, read-only macOS hosted validation for the SDK-free baseline and

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+
 .PHONY: build check lint static-check test verify
 
 check: verify
@@ -5,4 +7,4 @@ check: verify
 lint test build verify: static-check
 
 static-check:
-	python3 scripts/check-baseline.py
+	python3 "$(ROOT)/scripts/check-baseline.py"

--- a/NetworkState/NetworkState.swift
+++ b/NetworkState/NetworkState.swift
@@ -11,11 +11,13 @@ import SystemConfiguration
 public class NetworkState {
     public class func isConnectedToNetwork() -> Bool {
         var zeroAddress = sockaddr_in()
-        zeroAddress.sin_len = UInt8(sizeofValue(zeroAddress))
+        zeroAddress.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
         zeroAddress.sin_family = sa_family_t(AF_INET)
 
-        let defaultRouteReachability = withUnsafePointer(&zeroAddress) {
-            SCNetworkReachabilityCreateWithAddress(nil, UnsafePointer($0))
+        let defaultRouteReachability = withUnsafePointer(to: &zeroAddress) {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                SCNetworkReachabilityCreateWithAddress(nil, $0)
+            }
         }
 
         guard let reachability = defaultRouteReachability else {
@@ -29,12 +31,12 @@ public class NetworkState {
         return isReachableWithFlags(flags)
     }
 
-    public class func isReachableWithFlags(flags: SCNetworkReachabilityFlags) -> Bool {
-        let isReachable = (flags.rawValue & UInt32(kSCNetworkFlagsReachable)) != 0
-        let needsConnection = (flags.rawValue & UInt32(kSCNetworkFlagsConnectionRequired)) != 0
-        let canConnectAutomatically = (flags.rawValue & UInt32(kSCNetworkFlagsConnectionOnDemand)) != 0 ||
-            (flags.rawValue & UInt32(kSCNetworkFlagsConnectionOnTraffic)) != 0
-        let interventionRequired = (flags.rawValue & UInt32(kSCNetworkFlagsInterventionRequired)) != 0
+    public class func isReachableWithFlags(_ flags: SCNetworkReachabilityFlags) -> Bool {
+        let isReachable = flags.contains(.reachable)
+        let needsConnection = flags.contains(.connectionRequired)
+        let canConnectAutomatically = flags.contains(.connectionOnDemand) ||
+            flags.contains(.connectionOnTraffic)
+        let interventionRequired = flags.contains(.interventionRequired)
         let canConnectWithoutUserInteraction = canConnectAutomatically && !interventionRequired
 
         return isReachable && (!needsConnection || canConnectWithoutUserInteraction)

--- a/NetworkState/NetworkState.swift
+++ b/NetworkState/NetworkState.swift
@@ -37,6 +37,6 @@ public class NetworkState {
         let interventionRequired = (flags.rawValue & UInt32(kSCNetworkFlagsInterventionRequired)) != 0
         let canConnectWithoutUserInteraction = canConnectAutomatically && !interventionRequired
 
-        return isReachable && !interventionRequired && (!needsConnection || canConnectWithoutUserInteraction)
+        return isReachable && (!needsConnection || canConnectWithoutUserInteraction)
     }
 }

--- a/NetworkStateTests/NetworkStateTests.swift
+++ b/NetworkStateTests/NetworkStateTests.swift
@@ -56,11 +56,11 @@ class NetworkStateTests: XCTestCase {
         XCTAssertTrue(NetworkState.isReachableWithFlags(SCNetworkReachabilityFlags(rawValue: reachable | connectionRequired | connectionOnDemand | connectionOnTraffic)))
     }
 
-    func testInterventionRequiredFlagPreventsReachability() {
+    func testInterventionRequiredDoesNotBlockEstablishedReachability() {
         let reachable = UInt32(kSCNetworkFlagsReachable)
         let interventionRequired = UInt32(kSCNetworkFlagsInterventionRequired)
 
-        XCTAssertFalse(NetworkState.isReachableWithFlags(SCNetworkReachabilityFlags(rawValue: reachable | interventionRequired)))
+        XCTAssertTrue(NetworkState.isReachableWithFlags(SCNetworkReachabilityFlags(rawValue: reachable | interventionRequired)))
     }
 
     func testAutomaticConnectionModesRequireNoUserIntervention() {
@@ -117,8 +117,8 @@ class NetworkStateTests: XCTestCase {
                             rawValue |= UInt32(kSCNetworkFlagsInterventionRequired)
                         }
 
-                        let expected = isReachable && !interventionRequired &&
-                            (!connectionRequired || canConnectAutomatically)
+                        let expected = isReachable &&
+                            (!connectionRequired || (canConnectAutomatically && !interventionRequired))
                         XCTAssertEqual(
                             NetworkState.isReachableWithFlags(SCNetworkReachabilityFlags(rawValue: rawValue)),
                             expected

--- a/NetworkStateTests/NetworkStateTests.swift
+++ b/NetworkStateTests/NetworkStateTests.swift
@@ -63,6 +63,19 @@ class NetworkStateTests: XCTestCase {
         XCTAssertFalse(NetworkState.isReachableWithFlags(SCNetworkReachabilityFlags(rawValue: reachable | interventionRequired)))
     }
 
+    func testAutomaticConnectionModesRequireNoUserIntervention() {
+        let reachable = UInt32(kSCNetworkFlagsReachable)
+        let connectionRequired = UInt32(kSCNetworkFlagsConnectionRequired)
+        let connectionOnDemand = UInt32(kSCNetworkFlagsConnectionOnDemand)
+        let connectionOnTraffic = UInt32(kSCNetworkFlagsConnectionOnTraffic)
+        let interventionRequired = UInt32(kSCNetworkFlagsInterventionRequired)
+        let requiredFlags = reachable | connectionRequired | interventionRequired
+
+        XCTAssertFalse(NetworkState.isReachableWithFlags(SCNetworkReachabilityFlags(rawValue: requiredFlags | connectionOnDemand)))
+        XCTAssertFalse(NetworkState.isReachableWithFlags(SCNetworkReachabilityFlags(rawValue: requiredFlags | connectionOnTraffic)))
+        XCTAssertFalse(NetworkState.isReachableWithFlags(SCNetworkReachabilityFlags(rawValue: requiredFlags | connectionOnDemand | connectionOnTraffic)))
+    }
+
     func testNonReachabilityFlagsDoNotCreateConnectivity() {
         let reachable = UInt32(kSCNetworkFlagsReachable)
         let transientConnection = UInt32(kSCNetworkFlagsTransientConnection)

--- a/NetworkStateTests/NetworkStateTests.swift
+++ b/NetworkStateTests/NetworkStateTests.swift
@@ -95,4 +95,41 @@ class NetworkStateTests: XCTestCase {
         XCTAssertTrue(NetworkState.isReachableWithFlags(SCNetworkReachabilityFlags(rawValue: reachable | wwan)))
     }
 
+    func testReachabilityDecisionTruthTable() {
+        let booleanValues = [false, true]
+        var coveredRows = 0
+
+        for isReachable in booleanValues {
+            for connectionRequired in booleanValues {
+                for canConnectAutomatically in booleanValues {
+                    for interventionRequired in booleanValues {
+                        var rawValue: UInt32 = 0
+                        if isReachable {
+                            rawValue |= UInt32(kSCNetworkFlagsReachable)
+                        }
+                        if connectionRequired {
+                            rawValue |= UInt32(kSCNetworkFlagsConnectionRequired)
+                        }
+                        if canConnectAutomatically {
+                            rawValue |= UInt32(kSCNetworkFlagsConnectionOnDemand)
+                        }
+                        if interventionRequired {
+                            rawValue |= UInt32(kSCNetworkFlagsInterventionRequired)
+                        }
+
+                        let expected = isReachable && !interventionRequired &&
+                            (!connectionRequired || canConnectAutomatically)
+                        XCTAssertEqual(
+                            NetworkState.isReachableWithFlags(SCNetworkReachabilityFlags(rawValue: rawValue)),
+                            expected
+                        )
+                        coveredRows += 1
+                    }
+                }
+            }
+        }
+
+        XCTAssertEqual(coveredRows, 16)
+    }
+
 }

--- a/NetworkStateTests/NetworkStateTests.swift
+++ b/NetworkStateTests/NetworkStateTests.swift
@@ -18,8 +18,8 @@ class NetworkStateTests: XCTestCase {
     }
 
     func testReachabilityFlagEvaluation() {
-        let reachable = UInt32(kSCNetworkFlagsReachable)
-        let connectionRequired = UInt32(kSCNetworkFlagsConnectionRequired)
+        let reachable = SCNetworkReachabilityFlags.reachable.rawValue
+        let connectionRequired = SCNetworkReachabilityFlags.connectionRequired.rawValue
 
         XCTAssertTrue(NetworkState.isReachableWithFlags(SCNetworkReachabilityFlags(rawValue: reachable)))
         XCTAssertFalse(NetworkState.isReachableWithFlags(SCNetworkReachabilityFlags(rawValue: reachable | connectionRequired)))
@@ -27,11 +27,11 @@ class NetworkStateTests: XCTestCase {
     }
 
     func testReachabilityFlagEvaluationAllowsAutomaticConnection() {
-        let reachable = UInt32(kSCNetworkFlagsReachable)
-        let connectionRequired = UInt32(kSCNetworkFlagsConnectionRequired)
-        let connectionOnDemand = UInt32(kSCNetworkFlagsConnectionOnDemand)
-        let connectionOnTraffic = UInt32(kSCNetworkFlagsConnectionOnTraffic)
-        let interventionRequired = UInt32(kSCNetworkFlagsInterventionRequired)
+        let reachable = SCNetworkReachabilityFlags.reachable.rawValue
+        let connectionRequired = SCNetworkReachabilityFlags.connectionRequired.rawValue
+        let connectionOnDemand = SCNetworkReachabilityFlags.connectionOnDemand.rawValue
+        let connectionOnTraffic = SCNetworkReachabilityFlags.connectionOnTraffic.rawValue
+        let interventionRequired = SCNetworkReachabilityFlags.interventionRequired.rawValue
 
         XCTAssertTrue(NetworkState.isReachableWithFlags(SCNetworkReachabilityFlags(rawValue: reachable | connectionRequired | connectionOnDemand)))
         XCTAssertTrue(NetworkState.isReachableWithFlags(SCNetworkReachabilityFlags(rawValue: reachable | connectionRequired | connectionOnTraffic)))
@@ -39,36 +39,36 @@ class NetworkStateTests: XCTestCase {
     }
 
     func testAutomaticConnectionStillRequiresReachableFlag() {
-        let connectionRequired = UInt32(kSCNetworkFlagsConnectionRequired)
-        let connectionOnDemand = UInt32(kSCNetworkFlagsConnectionOnDemand)
-        let connectionOnTraffic = UInt32(kSCNetworkFlagsConnectionOnTraffic)
+        let connectionRequired = SCNetworkReachabilityFlags.connectionRequired.rawValue
+        let connectionOnDemand = SCNetworkReachabilityFlags.connectionOnDemand.rawValue
+        let connectionOnTraffic = SCNetworkReachabilityFlags.connectionOnTraffic.rawValue
 
         XCTAssertFalse(NetworkState.isReachableWithFlags(SCNetworkReachabilityFlags(rawValue: connectionRequired | connectionOnDemand)))
         XCTAssertFalse(NetworkState.isReachableWithFlags(SCNetworkReachabilityFlags(rawValue: connectionRequired | connectionOnTraffic)))
     }
 
     func testCombinedAutomaticConnectionFlagsAreReachable() {
-        let reachable = UInt32(kSCNetworkFlagsReachable)
-        let connectionRequired = UInt32(kSCNetworkFlagsConnectionRequired)
-        let connectionOnDemand = UInt32(kSCNetworkFlagsConnectionOnDemand)
-        let connectionOnTraffic = UInt32(kSCNetworkFlagsConnectionOnTraffic)
+        let reachable = SCNetworkReachabilityFlags.reachable.rawValue
+        let connectionRequired = SCNetworkReachabilityFlags.connectionRequired.rawValue
+        let connectionOnDemand = SCNetworkReachabilityFlags.connectionOnDemand.rawValue
+        let connectionOnTraffic = SCNetworkReachabilityFlags.connectionOnTraffic.rawValue
 
         XCTAssertTrue(NetworkState.isReachableWithFlags(SCNetworkReachabilityFlags(rawValue: reachable | connectionRequired | connectionOnDemand | connectionOnTraffic)))
     }
 
     func testInterventionRequiredDoesNotBlockEstablishedReachability() {
-        let reachable = UInt32(kSCNetworkFlagsReachable)
-        let interventionRequired = UInt32(kSCNetworkFlagsInterventionRequired)
+        let reachable = SCNetworkReachabilityFlags.reachable.rawValue
+        let interventionRequired = SCNetworkReachabilityFlags.interventionRequired.rawValue
 
         XCTAssertTrue(NetworkState.isReachableWithFlags(SCNetworkReachabilityFlags(rawValue: reachable | interventionRequired)))
     }
 
     func testAutomaticConnectionModesRequireNoUserIntervention() {
-        let reachable = UInt32(kSCNetworkFlagsReachable)
-        let connectionRequired = UInt32(kSCNetworkFlagsConnectionRequired)
-        let connectionOnDemand = UInt32(kSCNetworkFlagsConnectionOnDemand)
-        let connectionOnTraffic = UInt32(kSCNetworkFlagsConnectionOnTraffic)
-        let interventionRequired = UInt32(kSCNetworkFlagsInterventionRequired)
+        let reachable = SCNetworkReachabilityFlags.reachable.rawValue
+        let connectionRequired = SCNetworkReachabilityFlags.connectionRequired.rawValue
+        let connectionOnDemand = SCNetworkReachabilityFlags.connectionOnDemand.rawValue
+        let connectionOnTraffic = SCNetworkReachabilityFlags.connectionOnTraffic.rawValue
+        let interventionRequired = SCNetworkReachabilityFlags.interventionRequired.rawValue
         let requiredFlags = reachable | connectionRequired | interventionRequired
 
         XCTAssertFalse(NetworkState.isReachableWithFlags(SCNetworkReachabilityFlags(rawValue: requiredFlags | connectionOnDemand)))
@@ -77,10 +77,10 @@ class NetworkStateTests: XCTestCase {
     }
 
     func testNonReachabilityFlagsDoNotCreateConnectivity() {
-        let reachable = UInt32(kSCNetworkFlagsReachable)
-        let transientConnection = UInt32(kSCNetworkFlagsTransientConnection)
-        let localAddress = UInt32(kSCNetworkFlagsIsLocalAddress)
-        let direct = UInt32(kSCNetworkFlagsIsDirect)
+        let reachable = SCNetworkReachabilityFlags.reachable.rawValue
+        let transientConnection = SCNetworkReachabilityFlags.transientConnection.rawValue
+        let localAddress = SCNetworkReachabilityFlags.isLocalAddress.rawValue
+        let direct = SCNetworkReachabilityFlags.isDirect.rawValue
         let ancillaryFlags = transientConnection | localAddress | direct
 
         XCTAssertFalse(NetworkState.isReachableWithFlags(SCNetworkReachabilityFlags(rawValue: ancillaryFlags)))
@@ -88,11 +88,13 @@ class NetworkStateTests: XCTestCase {
     }
 
     func testWWANFlagRequiresReachableBaseFlag() {
-        let reachable = UInt32(kSCNetworkFlagsReachable)
-        let wwan = UInt32(kSCNetworkFlagsIsWWAN)
+#if os(iOS)
+        let reachable = SCNetworkReachabilityFlags.reachable.rawValue
+        let wwan = SCNetworkReachabilityFlags.isWWAN.rawValue
 
         XCTAssertFalse(NetworkState.isReachableWithFlags(SCNetworkReachabilityFlags(rawValue: wwan)))
         XCTAssertTrue(NetworkState.isReachableWithFlags(SCNetworkReachabilityFlags(rawValue: reachable | wwan)))
+#endif
     }
 
     func testReachabilityDecisionTruthTable() {
@@ -101,35 +103,41 @@ class NetworkStateTests: XCTestCase {
 
         for isReachable in booleanValues {
             for connectionRequired in booleanValues {
-                for canConnectAutomatically in booleanValues {
-                    for interventionRequired in booleanValues {
-                        var rawValue: UInt32 = 0
-                        if isReachable {
-                            rawValue |= UInt32(kSCNetworkFlagsReachable)
-                        }
-                        if connectionRequired {
-                            rawValue |= UInt32(kSCNetworkFlagsConnectionRequired)
-                        }
-                        if canConnectAutomatically {
-                            rawValue |= UInt32(kSCNetworkFlagsConnectionOnDemand)
-                        }
-                        if interventionRequired {
-                            rawValue |= UInt32(kSCNetworkFlagsInterventionRequired)
-                        }
+                for connectionOnDemand in booleanValues {
+                    for connectionOnTraffic in booleanValues {
+                        for interventionRequired in booleanValues {
+                            var rawValue: UInt32 = 0
+                            if isReachable {
+                                rawValue |= SCNetworkReachabilityFlags.reachable.rawValue
+                            }
+                            if connectionRequired {
+                                rawValue |= SCNetworkReachabilityFlags.connectionRequired.rawValue
+                            }
+                            if connectionOnDemand {
+                                rawValue |= SCNetworkReachabilityFlags.connectionOnDemand.rawValue
+                            }
+                            if connectionOnTraffic {
+                                rawValue |= SCNetworkReachabilityFlags.connectionOnTraffic.rawValue
+                            }
+                            if interventionRequired {
+                                rawValue |= SCNetworkReachabilityFlags.interventionRequired.rawValue
+                            }
 
-                        let expected = isReachable &&
-                            (!connectionRequired || (canConnectAutomatically && !interventionRequired))
-                        XCTAssertEqual(
-                            NetworkState.isReachableWithFlags(SCNetworkReachabilityFlags(rawValue: rawValue)),
-                            expected
-                        )
-                        coveredRows += 1
+                            let canConnectAutomatically = connectionOnDemand || connectionOnTraffic
+                            let expected = isReachable &&
+                                (!connectionRequired || (canConnectAutomatically && !interventionRequired))
+                            XCTAssertEqual(
+                                NetworkState.isReachableWithFlags(SCNetworkReachabilityFlags(rawValue: rawValue)),
+                                expected
+                            )
+                            coveredRows += 1
+                        }
                     }
                 }
             }
         }
 
-        XCTAssertEqual(coveredRows, 16)
+        XCTAssertEqual(coveredRows, 32)
     }
 
 }

--- a/NetworkStateTests/NetworkStateTests.swift
+++ b/NetworkStateTests/NetworkStateTests.swift
@@ -87,4 +87,12 @@ class NetworkStateTests: XCTestCase {
         XCTAssertTrue(NetworkState.isReachableWithFlags(SCNetworkReachabilityFlags(rawValue: reachable | ancillaryFlags)))
     }
 
+    func testWWANFlagRequiresReachableBaseFlag() {
+        let reachable = UInt32(kSCNetworkFlagsReachable)
+        let wwan = UInt32(kSCNetworkFlagsIsWWAN)
+
+        XCTAssertFalse(NetworkState.isReachableWithFlags(SCNetworkReachabilityFlags(rawValue: wwan)))
+        XCTAssertTrue(NetworkState.isReachableWithFlags(SCNetworkReachabilityFlags(rawValue: reachable | wwan)))
+    }
+
 }

--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
 - The non-reachability flag guard verifies transient, local-address, and direct
   bits cannot create connectivity without the `Reachable` flag.
 - Open `NetworkState.xcodeproj` in Xcode and run the `NetworkStateTests` scheme.
+- The Make gates are location-independent. From another directory, pass the
+  checkout's Makefile by absolute path, such as
+  `make -f /path/to/NetworkState/Makefile check`.
 - Run `./build.sh` when the required platform toolchain is installed. Override the simulator when needed:
 - The build script defaults `CODE_SIGNING_ALLOWED=NO` for simulator validation;
   override it only when intentionally testing signing behavior.
@@ -145,6 +148,7 @@ When the required SDK or runtime is unavailable, use static checks and source re
 - Run `make lint`, `make test`, `make build`, and `make check` before pushing
   changes, then run Xcode and CocoaPods verification on macOS when package
   metadata or Swift behavior changes.
+- Use an absolute Makefile path when running those gates outside the checkout.
 - Keep `NetworkState.podspec` and Xcode deployment targets aligned so package metadata does not claim unsupported iOS versions.
 - Keep framework version alignment between `NetworkState/Info.plist` and
   `NetworkState.podspec` before publishing package metadata.

--- a/README.md
+++ b/README.md
@@ -90,7 +90,8 @@ DESTINATION='platform=iOS Simulator,name=iPhone 6' ./build.sh
 - `make check`
 - Pinned `macos-15` GitHub Actions runs the SDK-free baseline and parses
   `NetworkState.xcodeproj` without simulator execution, signing, pod
-  publishing, or runtime connectivity checks.
+  publishing, or runtime connectivity checks. Checkout credentials are not
+  persisted after source retrieval.
 - `./build.sh` on macOS with Xcode
 - `pod spec lint NetworkState.podspec` when preparing CocoaPods release metadata
 - XCTest coverage includes reachable, connection-required, and unreachable reachability flag combinations.

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
   flag is present and no user intervention is required.
 - The intervention-required flag prevents reachability even when the base
   reachable flag is present.
+- The automatic intervention matrix covers on-demand, on-traffic, and combined
+  automatic modes so none report connectivity while user action is required.
 - The non-reachability flag guard verifies transient, local-address, and direct
   bits cannot create connectivity without the `Reachable` flag.
 - Open `NetworkState.xcodeproj` in Xcode and run the `NetworkStateTests` scheme.
@@ -114,6 +116,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   on-traffic states remain accepted together.
 - The intervention-required flag should keep user-action states from reporting
   connected.
+- The automatic intervention matrix should keep every automatic connection mode
+  unreachable while intervention is required.
 - Preserve the non-reachability flag guard when adding ancillary flag handling.
 - Review changes touching network requests, sockets, telemetry, or service endpoints; examples from the scan include NetworkState/Info.plist, NetworkStateTests/Info.plist.
 - Review changes touching file, media, JSON, XML, CSV, OCR, or data parsing; examples from the scan include NetworkState/Info.plist, NetworkStateTests/Info.plist.

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
   bits cannot create connectivity without the `Reachable` flag.
 - The WWAN reachability flag matrix verifies the cellular bit cannot create
   connectivity alone and remains accepted with `Reachable`.
+- The reachability decision truth table covers every combination of reachable,
+  connection-required, automatic-connect, and intervention-required state.
 - Open `NetworkState.xcodeproj` in Xcode and run the `NetworkStateTests` scheme.
 - The Make gates are location-independent. From another directory, pass the
   checkout's Makefile by absolute path, such as
@@ -142,6 +144,7 @@ When the required SDK or runtime is unavailable, use static checks and source re
   unreachable while intervention is required.
 - Preserve the non-reachability flag guard when adding ancillary flag handling.
 - Preserve the WWAN reachability flag matrix when changing cellular handling.
+- Preserve the reachability decision truth table when changing flag logic.
 - Review changes touching network requests, sockets, telemetry, or service endpoints; examples from the scan include NetworkState/Info.plist, NetworkStateTests/Info.plist.
 - Review changes touching file, media, JSON, XML, CSV, OCR, or data parsing; examples from the scan include NetworkState/Info.plist, NetworkStateTests/Info.plist.
 

--- a/README.md
+++ b/README.md
@@ -62,8 +62,9 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
 - Automatic connection handling still requires the reachable flag, so connection-on-demand flags alone do not report connectivity.
 - Combined automatic connection flags remain reachable when the base reachable
   flag is present and no user intervention is required.
-- The intervention-required flag prevents reachability even when the base
-  reachable flag is present.
+- The intervention-required flag prevents an automatic required connection
+  from being treated as reachable, but does not invalidate a route that is
+  already reachable without establishing a connection.
 - The automatic intervention matrix covers on-demand, on-traffic, and combined
   automatic modes so none report connectivity while user action is required.
 - The non-reachability flag guard verifies transient, local-address, and direct

--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
   automatic modes so none report connectivity while user action is required.
 - The non-reachability flag guard verifies transient, local-address, and direct
   bits cannot create connectivity without the `Reachable` flag.
+- The WWAN reachability flag matrix verifies the cellular bit cannot create
+  connectivity alone and remains accepted with `Reachable`.
 - Open `NetworkState.xcodeproj` in Xcode and run the `NetworkStateTests` scheme.
 - The Make gates are location-independent. From another directory, pass the
   checkout's Makefile by absolute path, such as
@@ -139,6 +141,7 @@ When the required SDK or runtime is unavailable, use static checks and source re
 - The automatic intervention matrix should keep every automatic connection mode
   unreachable while intervention is required.
 - Preserve the non-reachability flag guard when adding ancillary flag handling.
+- Preserve the WWAN reachability flag matrix when changing cellular handling.
 - Review changes touching network requests, sockets, telemetry, or service endpoints; examples from the scan include NetworkState/Info.plist, NetworkStateTests/Info.plist.
 - Review changes touching file, media, JSON, XML, CSV, OCR, or data parsing; examples from the scan include NetworkState/Info.plist, NetworkStateTests/Info.plist.
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,22 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
 DESTINATION='platform=iOS Simulator,name=iPhone 6' ./build.sh
 ```
 
+## Platform, Packaging, And Reachability Assumptions
+
+- `isConnectedToNetwork()` is a synchronous snapshot of
+  `SCNetworkReachability` flags for the IPv4 default route. It does not monitor
+  later network changes.
+- A `true` result does not prove internet access, DNS resolution, captive-portal
+  completion, or availability of a specific service. Callers must still handle
+  request-level failures and timeouts.
+- The podspec declares iOS 8.0 because this is a legacy compatibility boundary,
+  not a claim that the project builds unchanged with current Xcode or Swift.
+- CocoaPods is the only declared package-manager integration. Swift Package
+  Manager and Carthage are unsupported unless added in a separate reviewed
+  change.
+- The helper evaluates local SystemConfiguration state only. It performs no
+  remote probes, telemetry, request logging, or endpoint availability checks.
+
 ## Testing and Verification
 
 - `make lint`

--- a/README.md
+++ b/README.md
@@ -87,14 +87,15 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
   available to Xcode consumers alongside the test scheme.
 
 ```bash
-DESTINATION='platform=iOS Simulator,name=iPhone 6' ./build.sh
+DESTINATION='platform=iOS Simulator,name=iPhone 16 Pro' ./build.sh
 ```
 
 ## Platform, Packaging, And Reachability Assumptions
 
 - `isConnectedToNetwork()` is a synchronous snapshot of
   `SCNetworkReachability` flags for the IPv4 default route. It does not monitor
-  later network changes.
+  later network changes, install callbacks, schedule run-loop work, or own any
+  callback lifecycle.
 - A `true` result does not prove internet access, DNS resolution, captive-portal
   completion, or availability of a specific service. Callers must still handle
   request-level failures and timeouts.
@@ -139,8 +140,9 @@ When the required SDK or runtime is unavailable, use static checks and source re
 - Automatic connection behavior should keep the rule that it requires the reachable flag.
 - Combined automatic connection flags should stay covered so on-demand and
   on-traffic states remain accepted together.
-- The intervention-required flag should keep user-action states from reporting
-  connected.
+- The intervention-required flag should keep required connections that still
+  need user action from reporting connected without invalidating an already
+  established route.
 - The automatic intervention matrix should keep every automatic connection mode
   unreachable while intervention is required.
 - Preserve the non-reachability flag guard when adding ancillary flag handling.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -42,6 +42,8 @@ Helpful reports include:
   report connectivity without the `Reachable` bit.
 - The WWAN reachability flag matrix should keep the cellular bit dependent on
   `Reachable` without rejecting valid reachable cellular routes.
+- The reachability decision truth table should cover every boolean combination
+  that controls the public flag evaluator.
 - Review found network clients, sockets, web APIs, or service endpoints; changes in those areas should receive security-focused review before merge.
 - Review found file, document, data, or media parsing flows; changes in those areas should receive security-focused review before merge.
 - CocoaPods metadata lives in `NetworkState.podspec`. Run `make lint`,

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -33,6 +33,8 @@ Helpful reports include:
   on-traffic states remain accepted together when reachable.
 - The intervention-required flag should prevent connectivity from being
   reported when the network state still needs user action.
+- The automatic intervention matrix should cover on-demand, on-traffic, and
+  combined automatic modes with user intervention required.
 - The non-reachability flag guard should ensure ancillary route flags cannot
   report connectivity without the `Reachable` bit.
 - Review found network clients, sockets, web APIs, or service endpoints; changes in those areas should receive security-focused review before merge.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -29,6 +29,9 @@ Helpful reports include:
 - Reachability must remain a local flag snapshot with no remote probes. A
   positive result must not be documented as proof of internet access, DNS,
   captive-portal completion, or availability of a specific service.
+- The helper installs no reachability callback and owns no callback queue,
+  observer, or teardown lifecycle; callers must request a fresh snapshot when
+  their own application lifecycle requires one.
 - Reachability flag evaluation should remain deterministic and covered without live network telemetry.
 - Automatic connection reachability flags should be evaluated locally and covered without live network telemetry.
 - Automatic connection handling should still require the reachable flag before reporting connectivity.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -40,6 +40,8 @@ Helpful reports include:
   combined automatic modes with user intervention required.
 - The non-reachability flag guard should ensure ancillary route flags cannot
   report connectivity without the `Reachable` bit.
+- The WWAN reachability flag matrix should keep the cellular bit dependent on
+  `Reachable` without rejecting valid reachable cellular routes.
 - Review found network clients, sockets, web APIs, or service endpoints; changes in those areas should receive security-focused review before merge.
 - Review found file, document, data, or media parsing flows; changes in those areas should receive security-focused review before merge.
 - CocoaPods metadata lives in `NetworkState.podspec`. Run `make lint`,

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -35,7 +35,8 @@ Helpful reports include:
 - Combined automatic connection flags should stay covered so on-demand and
   on-traffic states remain accepted together when reachable.
 - The intervention-required flag should prevent connectivity from being
-  reported when the network state still needs user action.
+  reported only when a required connection still needs user action; it should
+  not override an already established reachable route.
 - The automatic intervention matrix should cover on-demand, on-traffic, and
   combined automatic modes with user intervention required.
 - The non-reachability flag guard should ensure ancillary route flags cannot

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,6 +26,9 @@ Helpful reports include:
 
 - This repository appears to be an Apple platform application or Swift sample. The active security scope is the code and documentation on the default branch.
 - The core code uses `SystemConfiguration` reachability. Connectivity checks should remain local to the device and should not collect telemetry, browsing data, endpoint history, or packet contents.
+- Reachability must remain a local flag snapshot with no remote probes. A
+  positive result must not be documented as proof of internet access, DNS,
+  captive-portal completion, or availability of a specific service.
 - Reachability flag evaluation should remain deterministic and covered without live network telemetry.
 - Automatic connection reachability flags should be evaluated locally and covered without live network telemetry.
 - Automatic connection handling should still require the reachable flag before reporting connectivity.
@@ -43,6 +46,9 @@ Helpful reports include:
   `make test`, `make build`, `make check`, and
   `pod spec lint NetworkState.podspec` before publishing package metadata
   changes.
+- CocoaPods is the only declared package-manager integration. Swift Package
+  Manager and Carthage support require separate metadata and verification
+  before being advertised.
 - The pinned macOS workflow runs static checks and project parsing without
   simulator execution, signing, pod publishing, or runtime connectivity checks.
 - The Xcode project and podspec should stay aligned on iOS 8.0 support so consumers do not receive inconsistent package metadata.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -64,6 +64,9 @@ files, and generated build products out of git. Preserve the shared framework
 scheme when changing project metadata so package verification remains
 repeatable.
 
+The hosted gate uses a credential-free checkout so its read-only token is not
+retained in the runner's Git configuration.
+
 ## Safe Research Guidelines
 
 Good-faith research is welcome when it stays within these boundaries:

--- a/VISION.md
+++ b/VISION.md
@@ -23,7 +23,8 @@ Priority:
 - Keep automatic connection reachability flags covered without live network state
 - Keep automatic connection behavior constrained so it requires the reachable flag
 - Keep combined automatic connection flags covered in fixture tests
-- Keep the intervention-required flag from reporting connectivity
+- Keep intervention-required handling scoped to connections that must first be
+  established
 - Keep the automatic intervention matrix across every automatic connection mode
 - Keep the non-reachability flag guard around ancillary route flags
 - Keep the WWAN reachability flag matrix around cellular routes

--- a/VISION.md
+++ b/VISION.md
@@ -38,6 +38,7 @@ Priority:
   SDK-free static baseline
 - Keep hosted macOS project parsing pinned, read-only, and separate from the
   legacy simulator build
+- Keep hosted source retrieval credential-free after checkout
 
 Next priorities:
 

--- a/VISION.md
+++ b/VISION.md
@@ -26,6 +26,7 @@ Priority:
 - Keep the intervention-required flag from reporting connectivity
 - Keep the automatic intervention matrix across every automatic connection mode
 - Keep the non-reachability flag guard around ancillary route flags
+- Keep the WWAN reachability flag matrix around cellular routes
 - Avoid growing the library beyond focused reachability utilities
 - Keep `SystemConfiguration` checks local to the device
 - Keep simulator verification independent of local signing identities by
@@ -67,6 +68,7 @@ Contribution rules:
 - Preserve combined automatic connection flags coverage when changing flag logic.
 - Preserve intervention-required flag handling when changing reachability logic.
 - Preserve the non-reachability flag guard when changing ancillary flag logic.
+- Preserve the WWAN reachability flag matrix when changing cellular flag logic.
 - Preserve deployment target alignment when changing package metadata.
 - Preserve framework version alignment when changing release metadata.
 - Preserve the shared framework scheme when changing Xcode project metadata.

--- a/VISION.md
+++ b/VISION.md
@@ -45,7 +45,8 @@ Priority:
 - Keep the platform contract explicit: iOS 8.0 is a legacy package boundary,
   not a current-Xcode compatibility claim
 - Keep reachability documented as a synchronous IPv4 default-route flag
-  snapshot rather than proof of internet or service availability
+  snapshot with no callback scheduling or observer lifecycle, rather than proof
+  of internet or service availability
 - Keep CocoaPods as the only declared package-manager integration until another
   manager is added and verified in a focused change
 - Keep connectivity evaluation local to the device with no remote probes,

--- a/VISION.md
+++ b/VISION.md
@@ -27,6 +27,7 @@ Priority:
 - Keep the automatic intervention matrix across every automatic connection mode
 - Keep the non-reachability flag guard around ancillary route flags
 - Keep the WWAN reachability flag matrix around cellular routes
+- Keep the reachability decision truth table exhaustive across decision flags
 - Avoid growing the library beyond focused reachability utilities
 - Keep `SystemConfiguration` checks local to the device
 - Keep simulator verification independent of local signing identities by

--- a/VISION.md
+++ b/VISION.md
@@ -39,13 +39,19 @@ Priority:
 - Keep hosted macOS project parsing pinned, read-only, and separate from the
   legacy simulator build
 - Keep hosted source retrieval credential-free after checkout
+- Keep the platform contract explicit: iOS 8.0 is a legacy package boundary,
+  not a current-Xcode compatibility claim
+- Keep reachability documented as a synchronous IPv4 default-route flag
+  snapshot rather than proof of internet or service availability
+- Keep CocoaPods as the only declared package-manager integration until another
+  manager is added and verified in a focused change
+- Keep connectivity evaluation local to the device with no remote probes,
+  telemetry, or endpoint checks
 
 Next priorities:
 
-- Document platform and network-framework assumptions
 - Modernize Swift/project settings in a dedicated pass
 - Add tests for offline, online, and constrained network cases where practical
-- Clarify package-manager support if revived
 - Run `pod spec lint NetworkState.podspec` on macOS before any package release
 
 Contribution rules:

--- a/VISION.md
+++ b/VISION.md
@@ -24,6 +24,7 @@ Priority:
 - Keep automatic connection behavior constrained so it requires the reachable flag
 - Keep combined automatic connection flags covered in fixture tests
 - Keep the intervention-required flag from reporting connectivity
+- Keep the automatic intervention matrix across every automatic connection mode
 - Keep the non-reachability flag guard around ancillary route flags
 - Avoid growing the library beyond focused reachability utilities
 - Keep `SystemConfiguration` checks local to the device

--- a/build.sh
+++ b/build.sh
@@ -4,8 +4,10 @@ set -eu
 
 PROJECT=${PROJECT:-NetworkState.xcodeproj}
 SCHEME=${SCHEME:-NetworkStateTests}
-DESTINATION=${DESTINATION:-platform=iOS Simulator,name=iPhone 5}
+DESTINATION=${DESTINATION:-platform=iOS Simulator,name=iPhone 16 Pro}
 SDK=${SDK:-iphonesimulator}
+SWIFT_VERSION=${SWIFT_VERSION:-5.0}
+IPHONEOS_DEPLOYMENT_TARGET=${IPHONEOS_DEPLOYMENT_TARGET:-12.0}
 CODE_SIGNING_ALLOWED=${CODE_SIGNING_ALLOWED:-NO}
 
 if ! command -v xcodebuild >/dev/null 2>&1; then
@@ -17,5 +19,7 @@ xcodebuild -project "${PROJECT}" \
            -scheme "${SCHEME}" \
            -destination "${DESTINATION}" \
            -sdk "${SDK}" \
+           SWIFT_VERSION="${SWIFT_VERSION}" \
+           IPHONEOS_DEPLOYMENT_TARGET="${IPHONEOS_DEPLOYMENT_TARGET}" \
            CODE_SIGNING_ALLOWED="${CODE_SIGNING_ALLOWED}" \
            build test

--- a/docs/plans/2026-06-12-automatic-intervention-matrix.md
+++ b/docs/plans/2026-06-12-automatic-intervention-matrix.md
@@ -1,6 +1,6 @@
 # Automatic Intervention Matrix
 
-status: planned
+status: completed
 
 ## Context
 
@@ -42,14 +42,20 @@ documentation.
 
 ## Verification
 
+Completed locally on 2026-06-12:
+
 - `python3 -m py_compile scripts/check-baseline.py`
 - `make lint`
 - `make test`
 - `make build`
 - `make check`
-- hostile mutations removing on-traffic or combined intervention coverage
+- hostile mutations removing on-traffic or combined intervention coverage were
+  each rejected by the static contract
 - `git diff --check`
-- hosted push and pull-request checks
+
+`xcodebuild` is unavailable on this Linux host, so XCTest was not executed
+locally. Hosted push and pull-request checks will be recorded after the branch
+is pushed.
 
 ## Boundaries
 

--- a/docs/plans/2026-06-12-automatic-intervention-matrix.md
+++ b/docs/plans/2026-06-12-automatic-intervention-matrix.md
@@ -1,0 +1,58 @@
+# Automatic Intervention Matrix
+
+status: planned
+
+## Context
+
+The reachability predicate rejects user-intervention-required states, including
+automatic connection modes. Existing XCTest coverage protects on-demand plus
+intervention, but not on-traffic or the combined automatic flags. A future
+condition refactor could therefore make one automatic mode report connectivity
+while still requiring user action.
+
+## Priorities
+
+1. Cover on-demand, on-traffic, and combined automatic modes with intervention.
+2. Require reachable and connection-required flags in each fixture.
+3. Preserve the production predicate and public API unchanged.
+4. Enforce the matrix through the portable static checker.
+
+## Implementation Units
+
+### XCTest Matrix
+
+File: `NetworkStateTests/NetworkStateTests.swift`
+
+Add a focused test asserting all three automatic-mode combinations remain
+unreachable when `kSCNetworkFlagsInterventionRequired` is present.
+
+### Static Contract And Documentation
+
+Files:
+
+- `scripts/check-baseline.py`
+- `README.md`
+- `SECURITY.md`
+- `VISION.md`
+- `CHANGES.md`
+- `docs/plans/2026-06-12-automatic-intervention-matrix.md`
+
+Require the three fixtures, completed evidence, and synchronized reachability
+documentation.
+
+## Verification
+
+- `python3 -m py_compile scripts/check-baseline.py`
+- `make lint`
+- `make test`
+- `make build`
+- `make check`
+- hostile mutations removing on-traffic or combined intervention coverage
+- `git diff --check`
+- hosted push and pull-request checks
+
+## Boundaries
+
+- Do not make live network requests or collect telemetry.
+- Do not change the public API or production flag predicate.
+- Do not claim XCTest execution without a compatible Xcode test environment.

--- a/docs/plans/2026-06-12-automatic-intervention-matrix.md
+++ b/docs/plans/2026-06-12-automatic-intervention-matrix.md
@@ -54,8 +54,13 @@ Completed locally on 2026-06-12:
 - `git diff --check`
 
 `xcodebuild` is unavailable on this Linux host, so XCTest was not executed
-locally. Hosted push and pull-request checks will be recorded after the branch
-is pushed.
+locally.
+
+Completed on hosted macOS for implementation head
+`70801c49325700194ab14fa3ea44a22c7747fc80`:
+
+- push run `27397655613`: success
+- pull-request run `27397656753`: success
 
 ## Boundaries
 

--- a/docs/plans/2026-06-12-checkout-credential-boundary.md
+++ b/docs/plans/2026-06-12-checkout-credential-boundary.md
@@ -1,0 +1,34 @@
+# Checkout Credential Boundary
+
+status: completed
+
+## Context
+
+The hosted macOS gate performs no authenticated Git operation after checkout,
+but the action default retained the read-only workflow token in the runner's
+Git configuration.
+
+## Implementation
+
+- Set `persist-credentials: false` on the single commit-pinned checkout step.
+- Require exactly one checkout action and only the canonical workflow file.
+- Preserve the macOS 15 runner, read-only permission, timeout, concurrency, and
+  `make check` command.
+- Document the credential-free checkout boundary.
+
+## Verification
+
+- `make lint`, `make test`, `make build`, and `make check` passed.
+- The checker passed from an external working directory.
+- Workflow YAML parsing, Python compilation, and `git diff --check` passed.
+- Focused hostile mutations rejected a missing or true credential setting,
+  duplicate checkout action, extra workflow file, incomplete plan, and stale
+  documentation; all hostile mutations rejected.
+- Exact-head hosted verification remains pending until this successor is
+  pushed.
+
+## Boundaries
+
+- Do not add post-checkout pushes, tags, or authenticated Git fetches.
+- Keep simulator execution, signing, pod publishing, and runtime connectivity
+  checks outside this static hosted gate.

--- a/docs/plans/2026-06-13-location-independent-make.md
+++ b/docs/plans/2026-06-13-location-independent-make.md
@@ -1,6 +1,6 @@
 # Location-Independent NetworkState Verification
 
-status: in progress
+status: completed
 
 ## Context
 
@@ -40,3 +40,25 @@ mutation verification after it completes.
 - Do not run dependency installation, builds, signing, simulators, remote
   probes, or application execution.
 - Preserve the existing stacked PR chain and exact-head evidence.
+
+## Work Completed
+
+- Rooted every SDK-free Make alias at the checkout containing the loaded
+  Makefile while preserving the existing target graph.
+- Added exact Makefile, README invocation, completed status, and verification
+  evidence contracts to `scripts/check-baseline.py`.
+- Documented absolute Makefile invocation without changing Swift, Xcode, or
+  workflow behavior.
+
+## Verification Completed
+
+- Root and external-directory `lint`, `test`, `build`, `verify`, and `check`
+  gates passed through the checkout's absolute Makefile path.
+- `python3 -m py_compile scripts/check-baseline.py` and `git diff --check`
+  passed.
+- Five isolated hostile mutations covering root derivation, checker resolution,
+  alias delegation, completed plan evidence, and README invocation guidance
+  were rejected by the intended contracts.
+- Intended-path, secret-pattern, conflict-marker, generated-artifact, Swift,
+  Xcode project, CocoaPods, test, workflow, and credential-boundary audits
+  passed.

--- a/docs/plans/2026-06-13-location-independent-make.md
+++ b/docs/plans/2026-06-13-location-independent-make.md
@@ -1,0 +1,42 @@
+# Location-Independent NetworkState Verification
+
+status: in progress
+
+## Context
+
+The SDK-free Make aliases invoke `scripts/check-baseline.py` relative to the
+caller's working directory. An absolute Makefile invocation from elsewhere can
+therefore fail or inspect the wrong tree instead of this checkout.
+
+## Objectives
+
+- Resolve every Make alias from the checkout containing the loaded Makefile.
+- Preserve the existing SDK-free target graph.
+- Enforce the exact rooted recipe, operator guidance, completed status, and
+  verification evidence in the active baseline checker.
+- Prove root and external-directory behavior with mutation-sensitive checks.
+
+## Implementation Units
+
+### Make Contract
+
+Files: `Makefile` and `scripts/check-baseline.py`.
+
+Derive one absolute root from the loaded Makefile and invoke the checker by
+absolute path. Require the complete small Makefile so aliases and path
+resolution cannot drift independently.
+
+### Documentation And Evidence
+
+Files: `README.md`, `CHANGES.md`, and this plan.
+
+Document absolute Makefile invocation and record bounded local and hostile
+mutation verification after it completes.
+
+## Boundaries
+
+- Do not change Swift, Xcode project files, CocoaPods metadata, tests,
+  workflows, or deployment targets.
+- Do not run dependency installation, builds, signing, simulators, remote
+  probes, or application execution.
+- Preserve the existing stacked PR chain and exact-head evidence.

--- a/docs/plans/2026-06-13-platform-network-assumptions.md
+++ b/docs/plans/2026-06-13-platform-network-assumptions.md
@@ -1,0 +1,67 @@
+---
+title: Document platform and network assumptions
+status: planned
+date: 2026-06-13
+---
+
+# Document Platform And Network Assumptions
+
+## Goal
+
+Make the supported platform, packaging, and reachability semantics explicit
+without changing the public `NetworkState.isConnectedToNetwork()` boolean API.
+
+## Decisions
+
+- Describe the helper as a synchronous snapshot of
+  `SCNetworkReachability` flags for the IPv4 default route.
+- State that a `true` result does not prove internet access, DNS resolution,
+  captive-portal completion, or availability of a specific service.
+- Preserve the current iOS 8.0 deployment target and legacy Swift/Xcode
+  compatibility boundary instead of claiming support for current toolchains.
+- Document CocoaPods as the only declared package-manager integration; Swift
+  Package Manager and Carthage remain unsupported unless added in a separate
+  reviewed change.
+- Keep reachability checks local to the device and free of telemetry, request
+  logging, or remote probes.
+
+## Implementation Units
+
+### Consumer documentation
+
+Files: `README.md`, `SECURITY.md`, `VISION.md`, `CHANGES.md`
+
+- Add a concise support and semantics section to the README.
+- Align security and vision language with the same local-only, no-probe
+  boundary.
+- Record the documentation contract in the changelog and mark the vision item
+  complete.
+
+### Regression contract
+
+Files: `scripts/check-baseline.py`
+
+- Require the README to retain the default-route snapshot limitation, the
+  non-guarantees for internet/service availability, the iOS 8.0 legacy
+  boundary, and CocoaPods-only package support.
+- Require security and vision documentation to retain the local-only/no-remote-
+  probe boundary.
+- Require this plan to record completed status and actual verification before
+  the full gate can pass.
+
+## Verification
+
+- Run `make lint`, `make test`, `make build`, and `make check`.
+- Run the checker from an external working directory.
+- Parse Python and workflow YAML, then run `git diff --check`.
+- Exercise hostile mutations that remove or weaken each documented assumption
+  and confirm the static gate rejects them.
+- Scan the intended diff for credential material and generated artifacts.
+
+## Risks
+
+- Documentation can overstate compatibility if it treats a metadata target as
+  proof of current Xcode support; wording must remain explicitly legacy-aware.
+- `SCNetworkReachability` flags are not a substitute for request-level error
+  handling, so the README must avoid presenting the helper as an internet
+  availability oracle.

--- a/docs/plans/2026-06-13-platform-network-assumptions.md
+++ b/docs/plans/2026-06-13-platform-network-assumptions.md
@@ -1,6 +1,6 @@
 ---
 title: Document platform and network assumptions
-status: planned
+status: completed
 date: 2026-06-13
 ---
 
@@ -65,3 +65,15 @@ Files: `scripts/check-baseline.py`
 - `SCNetworkReachability` flags are not a substitute for request-level error
   handling, so the README must avoid presenting the helper as an internet
   availability oracle.
+
+## Verification Result
+
+- `make lint`, `make test`, `make build`, and `make check` passed the complete
+  SDK-free baseline.
+- External-working-directory checker execution, Python compilation, workflow
+  YAML parsing, and `git diff --check` passed.
+- Six hostile mutations rejected weakened synchronous-snapshot, internet-
+  availability, package-manager, no-remote-probe, security non-guarantee, and
+  legacy-platform claims.
+- The intended documentation and checker diff passed credential-pattern and
+  generated-artifact scans.

--- a/docs/plans/2026-06-15-intervention-required-scope.md
+++ b/docs/plans/2026-06-15-intervention-required-scope.md
@@ -1,6 +1,6 @@
 # Intervention-Required Scope
 
-Status: planned
+Status: completed
 
 ## Problem
 
@@ -66,3 +66,25 @@ expected-value expression, so it cannot detect this boundary error.
 - A required connection remains unreachable when manual intervention is needed.
 - The exhaustive truth table and focused fixtures independently enforce both
   sides of that boundary.
+
+## Work Completed
+
+- Scoped the production intervention check to automatic connections that must
+  first be established.
+- Corrected the exhaustive truth-table oracle and added a focused established-
+  route fixture that rejects the previous global veto.
+- Strengthened the portable checker and synchronized user, security, vision,
+  and changelog guidance.
+
+## Verification Completed
+
+- All four Make gates passed from the repository and `make check` passed from
+  an external directory.
+- Six isolated hostile mutations were rejected for restoring the global veto,
+  weakening the focused fixture, weakening the truth-table oracle, removing
+  guidance, and reopening the plan status.
+- The exact eight-file implementation diff passed project/dependency,
+  generated-artifact, credential, conflict, binary, large-file, mode,
+  whitespace, and intended-path audits.
+- `xcodebuild` and XCTest were unavailable on Linux; the portable static iOS
+  baseline passed and no local runtime claim was made.

--- a/docs/plans/2026-06-15-intervention-required-scope.md
+++ b/docs/plans/2026-06-15-intervention-required-scope.md
@@ -1,0 +1,68 @@
+# Intervention-Required Scope
+
+Status: planned
+
+## Problem
+
+`NetworkState.isReachableWithFlags(_:)` currently treats
+`InterventionRequired` as a global connectivity veto. Apple documents that flag
+as describing manual action needed to establish a connection, alongside
+`ConnectionRequired`. A route that is already reachable without establishing a
+connection should therefore remain reachable even if a synthetic flag fixture
+also contains `InterventionRequired`.
+
+The exhaustive truth table currently repeats the production mistake in its
+expected-value expression, so it cannot detect this boundary error.
+
+## Scope
+
+- Apply `InterventionRequired` only while evaluating an automatically
+  established connection that is actually required.
+- Correct the 16-row truth-table oracle independently of the production
+  expression.
+- Add a focused fixture for `Reachable | InterventionRequired` without
+  `ConnectionRequired`.
+- Strengthen the portable checker and synchronize user and maintainer guidance.
+- Keep the public API, deployment targets, dependencies, project structure, and
+  workflows unchanged.
+
+## Files
+
+- `NetworkState/NetworkState.swift`
+- `NetworkStateTests/NetworkStateTests.swift`
+- `scripts/check-baseline.py`
+- `README.md`
+- `SECURITY.md`
+- `VISION.md`
+- `CHANGES.md`
+- `docs/plans/2026-06-15-intervention-required-scope.md`
+
+## Verification
+
+- Run every standard Make alias and invoke the absolute Makefile from an
+  external directory.
+- On Linux, report Xcode/XCTest unavailability rather than claiming runtime
+  execution.
+- Reject isolated mutations that restore the global intervention veto, weaken
+  the focused fixture or truth-table oracle, remove guidance, or reopen the
+  completed plan.
+- Audit the exact diff, generated artifacts, credentials, conflicts, binaries,
+  large files, modes, whitespace, and project/dependency drift.
+
+## Risks
+
+- Linux cannot execute XCTest; hosted macOS remains the runtime validation
+  boundary.
+- The corrected case is an unusual synthetic flag combination, but accepting it
+  follows the documented relationship between connection-required and
+  intervention-required state.
+- This change must remain stacked on PR #11, and no pull request may be merged
+  or closed without explicit owner authorization.
+
+## Success Criteria
+
+- `Reachable | InterventionRequired` remains reachable when no connection must
+  first be established.
+- A required connection remains unreachable when manual intervention is needed.
+- The exhaustive truth table and focused fixtures independently enforce both
+  sides of that boundary.

--- a/docs/plans/2026-06-15-reachability-decision-truth-table.md
+++ b/docs/plans/2026-06-15-reachability-decision-truth-table.md
@@ -1,6 +1,6 @@
 # Reachability Decision Truth Table
 
-Status: planned
+Status: completed
 
 ## Problem
 
@@ -60,3 +60,24 @@ the named examples while regressing an uncovered combination.
 - Existing focused flag fixtures remain intact and continue to pass the portable
   checker.
 - No production, dependency, project, or workflow file changes are introduced.
+
+## Work Completed
+
+- Added a nested four-dimension XCTest matrix that constructs concrete
+  reachability flags and checks all 16 combinations against the documented
+  decision rule.
+- Retained every existing focused fixture and left production code unchanged.
+- Added mutation-sensitive portable contracts and synchronized guidance.
+
+## Verification Completed
+
+- All four Make gates passed from the repository and `make check` passed from
+  an external directory.
+- Seven isolated hostile mutations were rejected for incomplete dimensions,
+  missing flag inputs, incorrect expected logic, weakened row count, missing
+  guidance, and stale plan status.
+- The exact seven-file implementation diff passed project/dependency,
+  generated-artifact, credential, conflict, binary, large-file, mode,
+  whitespace, and intended-path audits.
+- `xcodebuild` and XCTest were unavailable on Linux; the portable static iOS
+  baseline passed and no local runtime claim was made.

--- a/docs/plans/2026-06-15-reachability-decision-truth-table.md
+++ b/docs/plans/2026-06-15-reachability-decision-truth-table.md
@@ -1,0 +1,62 @@
+# Reachability Decision Truth Table
+
+Status: planned
+
+## Problem
+
+`NetworkState.isReachableWithFlags(_:)` derives its result from four decision
+bits: `Reachable`, `ConnectionRequired`, either automatic-connection flag, and
+`InterventionRequired`. Existing fixtures cover important examples, but they do
+not prove every boolean combination. A future predicate change could preserve
+the named examples while regressing an uncovered combination.
+
+## Scope
+
+- Add an XCTest truth table covering all 16 combinations of the four decision
+  dimensions.
+- Derive concrete `SCNetworkReachabilityFlags` inputs for each row while using a
+  stable representative automatic flag.
+- Assert the production decision rule: connectivity requires `Reachable`, must
+  not require intervention, and when a connection is required it must be able
+  to connect automatically.
+- Keep the current production predicate, public API, deployment targets,
+  dependencies, project structure, and existing focused fixtures unchanged.
+- Add mutation-sensitive portable contracts and synchronized guidance.
+
+## Files
+
+- `NetworkStateTests/NetworkStateTests.swift`
+- `scripts/check-baseline.py`
+- `README.md`
+- `SECURITY.md`
+- `VISION.md`
+- `CHANGES.md`
+- `docs/plans/2026-06-15-reachability-decision-truth-table.md`
+
+## Verification
+
+- Run the portable static iOS baseline through all standard Make aliases and
+  from an external directory.
+- On this Linux host, truthfully report Xcode/XCTest availability rather than
+  claiming runtime execution.
+- Reject isolated mutations for incomplete row coverage, incorrect expected
+  logic, missing decision inputs, missing guidance, and stale plan status.
+- Audit the exact diff, project/dependency drift, generated artifacts,
+  credentials, conflicts, binaries, large files, modes, and whitespace.
+
+## Risks
+
+- Linux cannot execute the XCTest target; hosted macOS remains the runtime
+  validation boundary.
+- The truth table characterizes the existing synchronous default-route
+  predicate and does not claim internet or service availability.
+- This change must remain stacked on PR #10; neither pull request may be merged
+  or closed without explicit owner authorization.
+
+## Success Criteria
+
+- Every combination of the four decision dimensions is represented exactly
+  once and checked against the documented boolean rule.
+- Existing focused flag fixtures remain intact and continue to pass the portable
+  checker.
+- No production, dependency, project, or workflow file changes are introduced.

--- a/docs/plans/2026-06-15-wwan-reachability-flag-matrix.md
+++ b/docs/plans/2026-06-15-wwan-reachability-flag-matrix.md
@@ -1,6 +1,6 @@
 # WWAN Reachability Flag Matrix
 
-status: in progress
+status: completed
 
 ## Problem
 
@@ -40,3 +40,25 @@ valid reachable cellular route without a focused regression.
 - This remains a local SystemConfiguration flag snapshot, not proof of internet
   access or availability of any remote service.
 - The stacked base pull request must remain available and merge first.
+
+## Work Completed
+
+- Added a focused XCTest fixture for `kSCNetworkFlagsIsWWAN` with and without
+  the required `Reachable` bit.
+- Preserved the production predicate and all existing automatic, intervention,
+  and ancillary flag fixtures.
+- Added exact portable contracts and synchronized maintenance guidance.
+
+## Verification Completed
+
+- All four Make gates passed from the repository and the canonical check passed
+  from an external directory through the absolute Makefile path.
+- The baseline checker compiled and passed; local Linux reported the existing
+  `xcodebuild` limitation and completed the static iOS baseline.
+- Six isolated hostile mutations were rejected: missing WWAN constant, missing
+  unreachable assertion, missing reachable assertion, inverted reachability,
+  missing guidance, and stale plan status.
+- `git diff --check`, exact intended-path, generated-artifact,
+  credential-pattern, Xcode project, conflict-marker, binary, and large-file
+  audits passed.
+- No live network request, remote probe, simulator, or device was used.

--- a/docs/plans/2026-06-15-wwan-reachability-flag-matrix.md
+++ b/docs/plans/2026-06-15-wwan-reachability-flag-matrix.md
@@ -1,0 +1,42 @@
+# WWAN Reachability Flag Matrix
+
+status: in progress
+
+## Problem
+
+The fixture matrix proves transient, local-address, and direct-route flags
+cannot create connectivity, but it omits the iOS-specific
+`kSCNetworkFlagsIsWWAN` bit. Cellular reachability commonly includes that flag,
+so a predicate refactor could accidentally treat WWAN as sufficient or reject a
+valid reachable cellular route without a focused regression.
+
+## Scope
+
+- Prove WWAN alone remains unreachable.
+- Prove `Reachable | IsWWAN` remains reachable.
+- Preserve the production predicate, public API, automatic-connection matrix,
+  deployment target, framework metadata, and package support.
+- Add mutation-sensitive static contracts and synchronized guidance.
+
+## Implementation
+
+1. Add a focused XCTest fixture for WWAN with and without `Reachable`.
+2. Require both assertions and the iOS flag constant in the portable checker.
+3. Record the cellular flag matrix in project maintenance documentation.
+
+## Verification
+
+- Run checker compilation and every Make gate from the repository plus the
+  canonical gate from an external directory with explicit timeouts.
+- Reject isolated mutations that remove the WWAN constant, remove either
+  assertion, invert an assertion, remove guidance, or leave the plan incomplete.
+- Audit the exact diff, generated artifacts, credential patterns, Xcode project
+  integrity, conflict markers, binaries, large files, and intended paths.
+
+## Risks
+
+- Xcode and XCTest execution require a compatible macOS toolchain; Linux can
+  validate only the dependency-free source contract.
+- This remains a local SystemConfiguration flag snapshot, not proof of internet
+  access or availability of any remote service.
+- The stacked base pull request must remain available and merge first.

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -94,8 +94,10 @@ def main() -> int:
             failures.append(f"reachability flag evaluation must handle {phrase}")
     if "return isReachable &&" not in swift:
         failures.append("automatic reachability handling must still require the reachable flag")
-    if "return isReachable && !interventionRequired" not in swift:
-        failures.append("reachability evaluation must reject intervention-required states")
+    if "return isReachable && (!needsConnection || canConnectWithoutUserInteraction)" not in swift:
+        failures.append("reachability evaluation must scope intervention to required connections")
+    if "return isReachable && !interventionRequired" in swift:
+        failures.append("reachability evaluation must not apply intervention as a global veto")
     if "(flags.rawValue & UInt32(kSCNetworkFlagsReachable)) != 0" not in swift:
         failures.append("reachability evaluation must derive connectivity from the Reachable flag")
 
@@ -112,8 +114,14 @@ def main() -> int:
         failures.append("tests must cover automatic connection flags without the reachable flag")
     if "testCombinedAutomaticConnectionFlagsAreReachable" not in tests:
         failures.append("tests must cover combined automatic connection reachability flags")
-    if "testInterventionRequiredFlagPreventsReachability" not in tests:
-        failures.append("tests must cover intervention-required reachability flags")
+    established_intervention_test = tests.split("func testInterventionRequiredDoesNotBlockEstablishedReachability()", 1)[-1].split("\n    func ", 1)[0]
+    if (
+        "func testInterventionRequiredDoesNotBlockEstablishedReachability()" not in tests
+        or "reachable | interventionRequired" not in established_intervention_test
+        or established_intervention_test.count("XCTAssertTrue") != 1
+        or "XCTAssertFalse" in established_intervention_test
+    ):
+        failures.append("tests must keep established reachability independent of intervention state")
     automatic_intervention_test = tests.split("func testAutomaticConnectionModesRequireNoUserIntervention()", 1)[-1].split("func testNonReachabilityFlagsDoNotCreateConnectivity()", 1)[0]
     if (
         "func testAutomaticConnectionModesRequireNoUserIntervention()" not in tests
@@ -153,8 +161,8 @@ def main() -> int:
         or "kSCNetworkFlagsConnectionRequired" not in truth_table_test
         or "kSCNetworkFlagsConnectionOnDemand" not in truth_table_test
         or "kSCNetworkFlagsInterventionRequired" not in truth_table_test
-        or "let expected = isReachable && !interventionRequired &&" not in truth_table_test
-        or "(!connectionRequired || canConnectAutomatically)" not in truth_table_test
+        or "let expected = isReachable &&" not in truth_table_test
+        or "(!connectionRequired || (canConnectAutomatically && !interventionRequired))" not in truth_table_test
         or "XCTAssertEqual(coveredRows, 16)" not in truth_table_test
     ):
         failures.append("tests must cover the complete reachability decision truth table")
@@ -262,6 +270,15 @@ def main() -> int:
             failures.append(f"{relative_path} must document the WWAN reachability flag matrix")
         if "reachability decision truth table" not in read(relative_path).lower():
             failures.append(f"{relative_path} must document the reachability decision truth table")
+    intervention_scope_guidance = {
+        "README.md": "does not invalidate a route that is already reachable",
+        "SECURITY.md": "only when a required connection still needs user action",
+        "VISION.md": "scoped to connections that must first be established",
+        "CHANGES.md": "preserving already reachable routes that need no connection",
+    }
+    for relative_path, phrase in intervention_scope_guidance.items():
+        if phrase not in " ".join(read(relative_path).split()):
+            failures.append(f"{relative_path} must document intervention-required scope")
 
     readme = " ".join(read("README.md").split())
     for phrase in [
@@ -362,6 +379,15 @@ def main() -> int:
         or re.search(r"(?i)\b(?:pending|todo|tbd|not run)\b", truth_table_plan)
     ):
         failures.append("reachability decision truth table plan must record completed verification")
+    intervention_scope_plan = read("docs/plans/2026-06-15-intervention-required-scope.md")
+    if (
+        "status: completed" not in intervention_scope_plan.lower()
+        or "All four Make gates passed" not in intervention_scope_plan
+        or "Six isolated hostile mutations were rejected" not in intervention_scope_plan
+        or "external directory" not in intervention_scope_plan
+        or re.search(r"(?i)\b(?:pending|todo|tbd|not run)\b", intervention_scope_plan)
+    ):
+        failures.append("intervention-required scope plan must record completed verification")
 
     hosted_plan = read("docs/plans/2026-06-10-hosted-project-validation.md")
     workflow = read(".github/workflows/check.yml")

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -43,6 +43,7 @@ REQUIRED = [
     "docs/plans/2026-06-10-non-reachability-flags.md",
     "docs/plans/2026-06-10-hosted-project-validation.md",
     "docs/plans/2026-06-12-automatic-intervention-matrix.md",
+    "docs/plans/2026-06-12-checkout-credential-boundary.md",
     "docs/readme-overview.svg",
 ]
 
@@ -264,6 +265,36 @@ def main() -> int:
     ]:
         if expected not in workflow:
             failures.append(f"Check workflow must keep {expected}")
+
+    checkout_plan = read("docs/plans/2026-06-12-checkout-credential-boundary.md")
+    if (
+        "status: completed" not in checkout_plan
+        or "persist-credentials: false" not in checkout_plan
+        or "hostile mutations rejected" not in checkout_plan
+    ):
+        failures.append("checkout credential plan must record completed verification")
+    workflow_files = sorted(
+        path.relative_to(ROOT).as_posix()
+        for path in (ROOT / ".github/workflows").iterdir()
+        if path.is_file()
+    )
+    if workflow_files != [".github/workflows/check.yml"]:
+        failures.append("workflow inventory must contain only .github/workflows/check.yml")
+    checkout_step = (
+        "      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10\n"
+        "        with:\n"
+        "          persist-credentials: false"
+    )
+    if workflow.count("actions/checkout@") != 1 or checkout_step not in workflow:
+        failures.append("Check workflow must keep one pinned credential-free checkout step")
+    if "persist-credentials: true" in workflow:
+        failures.append("Check workflow must not persist checkout credentials")
+    guidance = " ".join(
+        "\n".join(read(path) for path in ["README.md", "SECURITY.md", "VISION.md", "CHANGES.md"]).split()
+    ).lower()
+    for phrase in ["checkout credentials are not persisted", "credential-free checkout"]:
+        if phrase not in guidance:
+            failures.append(f"repository guidance must mention {phrase}")
 
     if shutil.which("xcodebuild"):
         result = subprocess.run(

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -11,6 +11,17 @@ import xml.etree.ElementTree as ET
 
 
 ROOT = Path(__file__).resolve().parents[1]
+EXPECTED_MAKEFILE = """ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+
+.PHONY: build check lint static-check test verify
+
+check: verify
+
+lint test build verify: static-check
+
+static-check:
+\tpython3 "$(ROOT)/scripts/check-baseline.py"
+"""
 REQUIRED = [
     ".gitignore",
     ".github/workflows/check.yml",
@@ -45,6 +56,7 @@ REQUIRED = [
     "docs/plans/2026-06-12-automatic-intervention-matrix.md",
     "docs/plans/2026-06-12-checkout-credential-boundary.md",
     "docs/plans/2026-06-13-platform-network-assumptions.md",
+    "docs/plans/2026-06-13-location-independent-make.md",
     "docs/readme-overview.svg",
 ]
 
@@ -127,13 +139,8 @@ def main() -> int:
         failures.append("build.sh must use POSIX shell function syntax or no shell functions")
 
     makefile = read("Makefile")
-    for phrase in [
-        ".PHONY: build check lint static-check test verify",
-        "check: verify",
-        "lint test build verify: static-check",
-    ]:
-        if phrase not in makefile:
-            failures.append(f"Makefile must include standard gate alias: {phrase}")
+    if makefile != EXPECTED_MAKEFILE:
+        failures.append("Makefile must exactly preserve rooted SDK-free aliases")
 
     podspec = read("NetworkState.podspec")
     podspec_version_match = re.search(r's\.version\s*=\s*"([^"]+)"', podspec)
@@ -182,7 +189,24 @@ def main() -> int:
         if expected not in gitignore:
             failures.append(f".gitignore must include {expected}")
 
-    docs = read("README.md") + "\n" + read("VISION.md") + "\n" + read("SECURITY.md")
+    readme_source = read("README.md")
+    docs = readme_source + "\n" + read("VISION.md") + "\n" + read("SECURITY.md")
+    location_independent_make_plan = read(
+        "docs/plans/2026-06-13-location-independent-make.md"
+    )
+    if "make -f /path/to/NetworkState/Makefile check" not in readme_source:
+        failures.append("README must document location-independent Makefile invocation")
+    if not all(
+        evidence in location_independent_make_plan.lower()
+        for evidence in [
+            "status: completed",
+            "root and external-directory",
+            "five isolated hostile mutations",
+        ]
+    ):
+        failures.append(
+            "location-independent Make plan must record completed root, external, and mutation verification"
+        )
     for phrase in [
         "make check",
         "pod spec lint",

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -42,6 +42,7 @@ REQUIRED = [
     "docs/plans/2026-06-10-shared-framework-scheme-guard.md",
     "docs/plans/2026-06-10-non-reachability-flags.md",
     "docs/plans/2026-06-10-hosted-project-validation.md",
+    "docs/plans/2026-06-12-automatic-intervention-matrix.md",
     "docs/readme-overview.svg",
 ]
 
@@ -97,6 +98,15 @@ def main() -> int:
         failures.append("tests must cover combined automatic connection reachability flags")
     if "testInterventionRequiredFlagPreventsReachability" not in tests:
         failures.append("tests must cover intervention-required reachability flags")
+    automatic_intervention_test = tests.split("func testAutomaticConnectionModesRequireNoUserIntervention()", 1)[-1].split("func testNonReachabilityFlagsDoNotCreateConnectivity()", 1)[0]
+    if (
+        "func testAutomaticConnectionModesRequireNoUserIntervention()" not in tests
+        or "requiredFlags | connectionOnDemand" not in automatic_intervention_test
+        or "requiredFlags | connectionOnTraffic" not in automatic_intervention_test
+        or "requiredFlags | connectionOnDemand | connectionOnTraffic" not in automatic_intervention_test
+        or automatic_intervention_test.count("XCTAssertFalse") != 3
+    ):
+        failures.append("tests must cover intervention across every automatic connection mode")
     if (
         "testNonReachabilityFlagsDoNotCreateConnectivity" not in tests
         or "kSCNetworkFlagsTransientConnection" not in tests
@@ -181,6 +191,7 @@ def main() -> int:
         "requires the reachable flag",
         "combined automatic connection flags",
         "intervention-required flag",
+        "automatic intervention matrix",
         "iOS 8.0",
         "framework version alignment",
         "shared framework scheme",
@@ -235,6 +246,9 @@ def main() -> int:
     non_reachability_plan = read("docs/plans/2026-06-10-non-reachability-flags.md")
     if "status: completed" not in non_reachability_plan or "make check" not in non_reachability_plan:
         failures.append("non-reachability flag guard plan must record status and verification")
+    automatic_intervention_plan = read("docs/plans/2026-06-12-automatic-intervention-matrix.md")
+    if "status: completed" not in automatic_intervention_plan or "hostile mutations" not in automatic_intervention_plan:
+        failures.append("automatic intervention matrix plan must record completed verification")
 
     hosted_plan = read("docs/plans/2026-06-10-hosted-project-validation.md")
     workflow = read(".github/workflows/check.yml")

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -128,6 +128,16 @@ def main() -> int:
         or "kSCNetworkFlagsIsDirect" not in tests
     ):
         failures.append("tests must cover ancillary flags with and without the Reachable flag")
+    wwan_test = tests.split("func testWWANFlagRequiresReachableBaseFlag()", 1)[-1].split("\n    func ", 1)[0]
+    if (
+        "func testWWANFlagRequiresReachableBaseFlag()" not in tests
+        or "kSCNetworkFlagsIsWWAN" not in wwan_test
+        or "XCTAssertFalse(NetworkState.isReachableWithFlags(SCNetworkReachabilityFlags(rawValue: wwan)))" not in wwan_test
+        or "XCTAssertTrue(NetworkState.isReachableWithFlags(SCNetworkReachabilityFlags(rawValue: reachable | wwan)))" not in wwan_test
+        or wwan_test.count("XCTAssertFalse") != 1
+        or wwan_test.count("XCTAssertTrue") != 1
+    ):
+        failures.append("tests must cover WWAN reachability with and without the Reachable flag")
     if "testExample" in tests or "testPerformanceExample" in tests:
         failures.append("placeholder XCTest methods must be replaced")
 
@@ -227,6 +237,9 @@ def main() -> int:
     ]:
         if phrase not in docs:
             failures.append(f"docs must mention {phrase}")
+    for relative_path in ["README.md", "SECURITY.md", "VISION.md", "CHANGES.md"]:
+        if "wwan reachability flag matrix" not in read(relative_path).lower():
+            failures.append(f"{relative_path} must document the WWAN reachability flag matrix")
 
     readme = " ".join(read("README.md").split())
     for phrase in [
@@ -310,6 +323,14 @@ def main() -> int:
     automatic_intervention_plan = read("docs/plans/2026-06-12-automatic-intervention-matrix.md")
     if "status: completed" not in automatic_intervention_plan or "hostile mutations" not in automatic_intervention_plan:
         failures.append("automatic intervention matrix plan must record completed verification")
+    wwan_plan = read("docs/plans/2026-06-15-wwan-reachability-flag-matrix.md")
+    if (
+        "status: completed" not in wwan_plan
+        or "All four Make gates passed" not in wwan_plan
+        or "Six isolated hostile mutations were rejected" not in wwan_plan
+        or "external directory" not in wwan_plan
+    ):
+        failures.append("WWAN reachability flag matrix plan must record completed verification")
 
     hosted_plan = read("docs/plans/2026-06-10-hosted-project-validation.md")
     workflow = read(".github/workflows/check.yml")

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -24,8 +24,10 @@ static-check:
 """
 REQUIRED = [
     ".gitignore",
+    ".github/CODEOWNERS",
     ".github/workflows/check.yml",
     ".travis.yml",
+    "AGENTS.md",
     "CHANGES.md",
     "Makefile",
     "NetworkState.podspec",
@@ -80,15 +82,15 @@ def main() -> int:
         failures.append("reachability creation must be guarded")
     if "defaultRouteReachability!" in swift:
         failures.append("reachability must not be force-unwrapped")
-    if "public class func isReachableWithFlags(flags: SCNetworkReachabilityFlags) -> Bool" not in swift:
+    if "public class func isReachableWithFlags(_ flags: SCNetworkReachabilityFlags) -> Bool" not in swift:
         failures.append("reachability flag evaluation must be exposed for fixture tests")
     if "return isReachableWithFlags(flags)" not in swift:
         failures.append("isConnectedToNetwork must use the shared flag evaluator")
     for phrase in [
         "canConnectAutomatically",
-        "kSCNetworkFlagsConnectionOnDemand",
-        "kSCNetworkFlagsConnectionOnTraffic",
-        "kSCNetworkFlagsInterventionRequired",
+        "flags.contains(.connectionOnDemand)",
+        "flags.contains(.connectionOnTraffic)",
+        "flags.contains(.interventionRequired)",
     ]:
         if phrase not in swift:
             failures.append(f"reachability flag evaluation must handle {phrase}")
@@ -98,7 +100,7 @@ def main() -> int:
         failures.append("reachability evaluation must scope intervention to required connections")
     if "return isReachable && !interventionRequired" in swift:
         failures.append("reachability evaluation must not apply intervention as a global veto")
-    if "(flags.rawValue & UInt32(kSCNetworkFlagsReachable)) != 0" not in swift:
+    if "flags.contains(.reachable)" not in swift:
         failures.append("reachability evaluation must derive connectivity from the Reachable flag")
 
     tests = read("NetworkStateTests/NetworkStateTests.swift")
@@ -133,15 +135,16 @@ def main() -> int:
         failures.append("tests must cover intervention across every automatic connection mode")
     if (
         "testNonReachabilityFlagsDoNotCreateConnectivity" not in tests
-        or "kSCNetworkFlagsTransientConnection" not in tests
-        or "kSCNetworkFlagsIsLocalAddress" not in tests
-        or "kSCNetworkFlagsIsDirect" not in tests
+        or "SCNetworkReachabilityFlags.transientConnection.rawValue" not in tests
+        or "SCNetworkReachabilityFlags.isLocalAddress.rawValue" not in tests
+        or "SCNetworkReachabilityFlags.isDirect.rawValue" not in tests
     ):
         failures.append("tests must cover ancillary flags with and without the Reachable flag")
     wwan_test = tests.split("func testWWANFlagRequiresReachableBaseFlag()", 1)[-1].split("\n    func ", 1)[0]
     if (
         "func testWWANFlagRequiresReachableBaseFlag()" not in tests
-        or "kSCNetworkFlagsIsWWAN" not in wwan_test
+        or "#if os(iOS)" not in wwan_test
+        or "SCNetworkReachabilityFlags.isWWAN.rawValue" not in wwan_test
         or "XCTAssertFalse(NetworkState.isReachableWithFlags(SCNetworkReachabilityFlags(rawValue: wwan)))" not in wwan_test
         or "XCTAssertTrue(NetworkState.isReachableWithFlags(SCNetworkReachabilityFlags(rawValue: reachable | wwan)))" not in wwan_test
         or wwan_test.count("XCTAssertFalse") != 1
@@ -152,25 +155,28 @@ def main() -> int:
     if (
         "func testReachabilityDecisionTruthTable()" not in tests
         or "let booleanValues = [false, true]" not in truth_table_test
-        or truth_table_test.count("for ") != 4
+        or truth_table_test.count("for ") != 5
         or "for isReachable in booleanValues" not in truth_table_test
         or "for connectionRequired in booleanValues" not in truth_table_test
-        or "for canConnectAutomatically in booleanValues" not in truth_table_test
+        or "for connectionOnDemand in booleanValues" not in truth_table_test
+        or "for connectionOnTraffic in booleanValues" not in truth_table_test
         or "for interventionRequired in booleanValues" not in truth_table_test
-        or "kSCNetworkFlagsReachable" not in truth_table_test
-        or "kSCNetworkFlagsConnectionRequired" not in truth_table_test
-        or "kSCNetworkFlagsConnectionOnDemand" not in truth_table_test
-        or "kSCNetworkFlagsInterventionRequired" not in truth_table_test
+        or "SCNetworkReachabilityFlags.reachable.rawValue" not in truth_table_test
+        or "SCNetworkReachabilityFlags.connectionRequired.rawValue" not in truth_table_test
+        or "SCNetworkReachabilityFlags.connectionOnDemand.rawValue" not in truth_table_test
+        or "SCNetworkReachabilityFlags.connectionOnTraffic.rawValue" not in truth_table_test
+        or "SCNetworkReachabilityFlags.interventionRequired.rawValue" not in truth_table_test
+        or "let canConnectAutomatically = connectionOnDemand || connectionOnTraffic" not in truth_table_test
         or "let expected = isReachable &&" not in truth_table_test
         or "(!connectionRequired || (canConnectAutomatically && !interventionRequired))" not in truth_table_test
-        or "XCTAssertEqual(coveredRows, 16)" not in truth_table_test
+        or "XCTAssertEqual(coveredRows, 32)" not in truth_table_test
     ):
         failures.append("tests must cover the complete reachability decision truth table")
     if "testExample" in tests or "testPerformanceExample" in tests:
         failures.append("placeholder XCTest methods must be replaced")
 
     build = read("build.sh")
-    for phrase in ["PROJECT=${PROJECT:-NetworkState.xcodeproj}", "SCHEME=${SCHEME:-NetworkStateTests}", "DESTINATION=${DESTINATION:-", "CODE_SIGNING_ALLOWED=${CODE_SIGNING_ALLOWED:-NO}", 'CODE_SIGNING_ALLOWED="${CODE_SIGNING_ALLOWED}"', "command -v xcodebuild"]:
+    for phrase in ["PROJECT=${PROJECT:-NetworkState.xcodeproj}", "SCHEME=${SCHEME:-NetworkStateTests}", "DESTINATION=${DESTINATION:-", "SWIFT_VERSION=${SWIFT_VERSION:-5.0}", "IPHONEOS_DEPLOYMENT_TARGET=${IPHONEOS_DEPLOYMENT_TARGET:-12.0}", "CODE_SIGNING_ALLOWED=${CODE_SIGNING_ALLOWED:-NO}", 'SWIFT_VERSION="${SWIFT_VERSION}"', 'IPHONEOS_DEPLOYMENT_TARGET="${IPHONEOS_DEPLOYMENT_TARGET}"', 'CODE_SIGNING_ALLOWED="${CODE_SIGNING_ALLOWED}"', "command -v xcodebuild"]:
         if phrase not in build:
             failures.append(f"build.sh must include {phrase}")
     if "function " in build:
@@ -391,6 +397,7 @@ def main() -> int:
 
     hosted_plan = read("docs/plans/2026-06-10-hosted-project-validation.md")
     workflow = read(".github/workflows/check.yml")
+    codeowners = read(".github/CODEOWNERS")
     if "status: completed" not in hosted_plan or "make check" not in hosted_plan:
         failures.append("hosted project validation plan must record status and verification")
     for expected in [
@@ -400,6 +407,7 @@ def main() -> int:
         "timeout-minutes: 10",
         "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10",
         "run: make check",
+        "run: ./build.sh",
     ]:
         if expected not in workflow:
             failures.append(f"Check workflow must keep {expected}")
@@ -434,6 +442,8 @@ def main() -> int:
         failures.append("Check workflow must keep one pinned credential-free checkout step")
     if "persist-credentials: true" in workflow:
         failures.append("Check workflow must not persist checkout credentials")
+    if codeowners.strip() != "* @garethpaul":
+        failures.append("CODEOWNERS must keep repository-wide owner review")
     guidance = " ".join(
         "\n".join(read(path) for path in ["README.md", "SECURITY.md", "VISION.md", "CHANGES.md"]).split()
     ).lower()

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -44,6 +44,7 @@ REQUIRED = [
     "docs/plans/2026-06-10-hosted-project-validation.md",
     "docs/plans/2026-06-12-automatic-intervention-matrix.md",
     "docs/plans/2026-06-12-checkout-credential-boundary.md",
+    "docs/plans/2026-06-13-platform-network-assumptions.md",
     "docs/readme-overview.svg",
 ]
 
@@ -203,6 +204,41 @@ def main() -> int:
         if phrase not in docs:
             failures.append(f"docs must mention {phrase}")
 
+    readme = " ".join(read("README.md").split())
+    for phrase in [
+        "synchronous snapshot",
+        "IPv4 default route",
+        "does not prove internet access",
+        "DNS resolution",
+        "captive-portal completion",
+        "availability of a specific service",
+        "legacy compatibility boundary",
+        "CocoaPods is the only declared package-manager integration",
+        "Swift Package Manager and Carthage are unsupported",
+        "no remote probes",
+    ]:
+        if phrase not in readme:
+            failures.append(f"README platform assumptions must mention {phrase}")
+
+    security = " ".join(read("SECURITY.md").split())
+    for phrase in [
+        "local flag snapshot with no remote probes",
+        "must not be documented as proof of internet access",
+        "CocoaPods is the only declared package-manager integration",
+    ]:
+        if phrase not in security:
+            failures.append(f"security platform assumptions must mention {phrase}")
+
+    vision = " ".join(read("VISION.md").split())
+    for phrase in [
+        "iOS 8.0 is a legacy package boundary",
+        "synchronous IPv4 default-route flag snapshot",
+        "CocoaPods as the only declared package-manager integration",
+        "no remote probes",
+    ]:
+        if phrase not in vision:
+            failures.append(f"vision platform assumptions must mention {phrase}")
+
     plan = read("docs/plans/2026-06-08-network-state-baseline.md")
     if "status: completed" not in plan or "make check" not in plan:
         failures.append("completed plan must record status and verification")
@@ -273,6 +309,13 @@ def main() -> int:
         or "hostile mutations rejected" not in checkout_plan
     ):
         failures.append("checkout credential plan must record completed verification")
+    assumptions_plan = read("docs/plans/2026-06-13-platform-network-assumptions.md")
+    if (
+        "status: completed" not in assumptions_plan
+        or "make check" not in assumptions_plan
+        or "hostile mutations rejected" not in assumptions_plan
+    ):
+        failures.append("platform assumptions plan must record completed verification")
     workflow_files = sorted(
         path.relative_to(ROOT).as_posix()
         for path in (ROOT / ".github/workflows").iterdir()

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -57,6 +57,8 @@ REQUIRED = [
     "docs/plans/2026-06-12-checkout-credential-boundary.md",
     "docs/plans/2026-06-13-platform-network-assumptions.md",
     "docs/plans/2026-06-13-location-independent-make.md",
+    "docs/plans/2026-06-15-reachability-decision-truth-table.md",
+    "docs/plans/2026-06-15-wwan-reachability-flag-matrix.md",
     "docs/readme-overview.svg",
 ]
 
@@ -138,6 +140,24 @@ def main() -> int:
         or wwan_test.count("XCTAssertTrue") != 1
     ):
         failures.append("tests must cover WWAN reachability with and without the Reachable flag")
+    truth_table_test = tests.split("func testReachabilityDecisionTruthTable()", 1)[-1].split("\n    func ", 1)[0]
+    if (
+        "func testReachabilityDecisionTruthTable()" not in tests
+        or "let booleanValues = [false, true]" not in truth_table_test
+        or truth_table_test.count("for ") != 4
+        or "for isReachable in booleanValues" not in truth_table_test
+        or "for connectionRequired in booleanValues" not in truth_table_test
+        or "for canConnectAutomatically in booleanValues" not in truth_table_test
+        or "for interventionRequired in booleanValues" not in truth_table_test
+        or "kSCNetworkFlagsReachable" not in truth_table_test
+        or "kSCNetworkFlagsConnectionRequired" not in truth_table_test
+        or "kSCNetworkFlagsConnectionOnDemand" not in truth_table_test
+        or "kSCNetworkFlagsInterventionRequired" not in truth_table_test
+        or "let expected = isReachable && !interventionRequired &&" not in truth_table_test
+        or "(!connectionRequired || canConnectAutomatically)" not in truth_table_test
+        or "XCTAssertEqual(coveredRows, 16)" not in truth_table_test
+    ):
+        failures.append("tests must cover the complete reachability decision truth table")
     if "testExample" in tests or "testPerformanceExample" in tests:
         failures.append("placeholder XCTest methods must be replaced")
 
@@ -240,6 +260,8 @@ def main() -> int:
     for relative_path in ["README.md", "SECURITY.md", "VISION.md", "CHANGES.md"]:
         if "wwan reachability flag matrix" not in read(relative_path).lower():
             failures.append(f"{relative_path} must document the WWAN reachability flag matrix")
+        if "reachability decision truth table" not in read(relative_path).lower():
+            failures.append(f"{relative_path} must document the reachability decision truth table")
 
     readme = " ".join(read("README.md").split())
     for phrase in [
@@ -331,6 +353,15 @@ def main() -> int:
         or "external directory" not in wwan_plan
     ):
         failures.append("WWAN reachability flag matrix plan must record completed verification")
+    truth_table_plan = read("docs/plans/2026-06-15-reachability-decision-truth-table.md")
+    if (
+        "status: completed" not in truth_table_plan.lower()
+        or "All four Make gates passed" not in truth_table_plan
+        or "Seven isolated hostile mutations were rejected" not in truth_table_plan
+        or "external directory" not in truth_table_plan
+        or re.search(r"(?i)\b(?:pending|todo|tbd|not run)\b", truth_table_plan)
+    ):
+        failures.append("reachability decision truth table plan must record completed verification")
 
     hosted_plan = read("docs/plans/2026-06-10-hosted-project-validation.md")
     workflow = read(".github/workflows/check.yml")


### PR DESCRIPTION
## Summary

Consolidate the reviewed reachability stack from #6 through #12 and the useful ownership and checkout-credential boundary from #5.

## Baseline

The branch stack contained overlapping fixes and plans. The inherited evaluator applied `InterventionRequired` as a global veto even when a route was already reachable, and the repository lacked consolidated native proof for the complete reachability truth table.

## Improvements

- Scope `InterventionRequired` to connections that still need establishment, preserving an already reachable route.
- Keep every positive result dependent on `Reachable`.
- Distinguish on-demand and on-traffic flags across the complete 32-row core truth table.
- Keep transient, local, direct, and iOS WWAN flags ancillary rather than independent reachability evidence.
- Modernize Swift syntax so the real XCTest suite runs on current Xcode without changing the public Boolean API or iOS 8 package declaration.
- Add a credential-free hosted native XCTest gate and repository-wide CODEOWNERS.
- Document that the API is a synchronous IPv4 default-route snapshot, not proof of internet, DNS, captive-portal, or service availability.

## Validation

- `make lint`, `make test`, `make build`, and `make check`
- External-directory absolute-Makefile `make check`
- Current Xcode: 10 XCTest cases, 0 failures
- Exhaustive 32-row core decision matrix plus ancillary and iOS WWAN cases
- Six native hostile mutations rejected: global intervention veto, missing Reachable requirement, ignored on-traffic, ignored intervention, WWAN-as-reachability, and ignored ConnectionRequired
- Three static hostile mutations rejected: removed native hosted gate, persisted checkout credentials, and removed WWAN platform guard
- `python3 -m py_compile`, `sh -n`, `git diff --check`, and Gitleaks

## Risk

No physical device, carrier transition, captive portal, VPN, DNS failure, remote service, or live callback timing was exercised. The API remains a synchronous local flag snapshot and callers must still attempt requests and handle failures.

## Follow-Ups

Preserve native XCTest coverage and hosted macOS validation for future flag changes. Treat live network success, service availability, and lifecycle monitoring as caller responsibilities rather than extending this Boolean snapshot API speculatively.
