### PR TITLE
fix: protect repository make root

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+override ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 
 .PHONY: build check lint static-check test verify
 

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -11,7 +11,7 @@ import xml.etree.ElementTree as ET
 
 
 ROOT = Path(__file__).resolve().parents[1]
-EXPECTED_MAKEFILE = """ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+EXPECTED_MAKEFILE = """override ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 
 .PHONY: build check lint static-check test verify
 


### PR DESCRIPTION
## Summary

Repository validation can no longer be redirected outside the checkout through a command-line `ROOT` override. The exact baseline oracle prevents the protection from being silently downgraded.

## Baseline

The Makefile accepted a caller-controlled `ROOT`, allowing SDK-free validation to inspect a path outside the repository. The static baseline did not require the protected root assignment.

## Improvements

The Makefile now overrides `ROOT` from its own checked-in path, and the baseline checker locks that fail-closed contract without changing Swift source, Xcode settings, package metadata, or runtime behavior.

## Validation

- `check`, `lint`, `test`, `build`, and `verify` passed from both the repository root and an external directory with a hostile `ROOT` value.
- Python compilation, `git diff --check`, strict Git object validation, and verified Gitleaks 8.30.1 history/current/commit scans passed with zero findings.
- All six registered worktrees and the protected WorkoutPact fleet remained byte/index identical.

## Risk

Linux cannot execute Xcode, SystemConfiguration, simulator, or device reachability behavior. No application runtime code changed, so exact-head hosted macOS validation remains the platform authority.

## Follow-Ups

No additional production monitoring is required because this changes repository validation only. Preserve protected `baseline` and CodeQL jobs on future exact heads; any failure in those gates should block delivery.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
