### PR TITLE
ci: preserve spaced absolute Makefile paths

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Changes
 
+## 2026-06-21
+
+- Preserved the complete checkout root for absolute Makefile paths containing
+  spaces, brackets, or apostrophes, and rejected `MAKEFILE_LIST` overrides.
+- Added three SDK-free regression tests across all six Make aliases.
+
 ## 2026-06-19
 
 - Made the reachability truth table executable on current Xcode while retaining

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
-override ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+ifneq ($(origin MAKEFILE_LIST),file)
+$(error MAKEFILE_LIST must not be overridden)
+endif
+override ROOT := $(shell path='$(subst ','"'"',$(MAKEFILE_LIST))'; path=$$(printf '%s\n' "$$path" | sed 's/^ //'); dirname -- "$$path")
 
 .PHONY: build check lint static-check test verify
 
@@ -8,3 +11,4 @@ lint test build verify: static-check
 
 static-check:
 	python3 "$(ROOT)/scripts/check-baseline.py"
+	PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s "$(ROOT)/tests" -p 'test_*.py'

--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
 - The Make gates are location-independent. From another directory, pass the
   checkout's Makefile by absolute path, such as
   `make -f /path/to/NetworkState/Makefile check`.
+- Absolute Makefile paths containing spaces, brackets, or apostrophes retain
+  the complete checkout root. `ROOT` overrides are ignored, and attempts to
+  override GNU Make's `MAKEFILE_LIST` metadata fail closed.
 - Run `./build.sh` when the required platform toolchain is installed. Override the simulator when needed:
 - The build script defaults `CODE_SIGNING_ALLOWED=NO` for simulator validation;
   override it only when intentionally testing signing behavior.

--- a/docs/plans/2026-06-21-spaced-makefile-path.md
+++ b/docs/plans/2026-06-21-spaced-makefile-path.md
@@ -1,0 +1,30 @@
+# Spaced Absolute Makefile Path Verification
+
+status: completed
+
+## Context
+
+GNU Make list functions split a loaded absolute Makefile path at spaces. A
+checkout path containing spaces, brackets, and an apostrophe therefore sent
+the SDK-free verifier to a fabricated caller path.
+
+## Scope
+
+1. Derive the checkout root from the complete `MAKEFILE_LIST` value.
+2. Preserve the authoritative root against command-line and environment input.
+3. Reject command-line or environment-preferred `MAKEFILE_LIST` overrides.
+4. Exercise all six Make aliases from an external working directory.
+
+## Verification
+
+- Root and external hostile-path gates passed on Python 3.12 and 3.14.
+- All six Make aliases retained the checkout with no override and with
+  command-line or environment `ROOT` input.
+- Both tested `MAKEFILE_LIST` override paths failed closed.
+- Static reachability, Xcode project, scheme, podspec, and workflow contracts
+  remained green; no Apple build ran locally.
+
+## Risk And Rollback
+
+This changes SDK-free verification root discovery only. It does not alter the
+Swift framework, reachability truth table, Xcode project, or build script.

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -11,7 +11,10 @@ import xml.etree.ElementTree as ET
 
 
 ROOT = Path(__file__).resolve().parents[1]
-EXPECTED_MAKEFILE = """override ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+EXPECTED_MAKEFILE = """ifneq ($(origin MAKEFILE_LIST),file)
+$(error MAKEFILE_LIST must not be overridden)
+endif
+override ROOT := $(shell path='$(subst ','"'"',$(MAKEFILE_LIST))'; path=$$(printf '%s\\n' "$$path" | sed 's/^ //'); dirname -- "$$path")
 
 .PHONY: build check lint static-check test verify
 
@@ -21,6 +24,7 @@ lint test build verify: static-check
 
 static-check:
 \tpython3 "$(ROOT)/scripts/check-baseline.py"
+\tPYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s "$(ROOT)/tests" -p 'test_*.py'
 """
 REQUIRED = [
     ".gitignore",
@@ -61,7 +65,9 @@ REQUIRED = [
     "docs/plans/2026-06-13-location-independent-make.md",
     "docs/plans/2026-06-15-reachability-decision-truth-table.md",
     "docs/plans/2026-06-15-wwan-reachability-flag-matrix.md",
+    "docs/plans/2026-06-21-spaced-makefile-path.md",
     "docs/readme-overview.svg",
+    "tests/test_makefile_root.py",
 ]
 
 
@@ -238,6 +244,7 @@ def main() -> int:
     location_independent_make_plan = read(
         "docs/plans/2026-06-13-location-independent-make.md"
     )
+    spaced_makefile_plan = read("docs/plans/2026-06-21-spaced-makefile-path.md")
     if "make -f /path/to/NetworkState/Makefile check" not in readme_source:
         failures.append("README must document location-independent Makefile invocation")
     if not all(
@@ -251,6 +258,13 @@ def main() -> int:
         failures.append(
             "location-independent Make plan must record completed root, external, and mutation verification"
         )
+    if not all(value in spaced_makefile_plan for value in [
+        "status: completed",
+        "spaces, brackets, and an apostrophe",
+        "MAKEFILE_LIST",
+        "all six Make aliases",
+    ]):
+        failures.append("spaced Makefile path plan must preserve hostile-path and override verification")
     for phrase in [
         "make check",
         "pod spec lint",

--- a/tests/test_makefile_root.py
+++ b/tests/test_makefile_root.py
@@ -1,0 +1,62 @@
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class MakefileRootTests(unittest.TestCase):
+    def run_make(self, *arguments, environment=None):
+        with tempfile.TemporaryDirectory(prefix="networkstate make path ") as directory:
+            root = Path(directory)
+            checkout = root / "checkout [hostile] 'quote"
+            checkout.mkdir()
+            makefile = checkout / "Makefile"
+            shutil.copyfile(ROOT / "Makefile", makefile)
+            external = root / "external caller"
+            external.mkdir()
+            env = os.environ.copy()
+            if environment:
+                env.update(environment)
+            result = subprocess.run(
+                ["make", "--no-print-directory", "-n", "-f", str(makefile), *arguments],
+                cwd=external,
+                env=env,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            return result, str(checkout)
+
+    def test_all_aliases_preserve_spaced_absolute_makefile_path(self):
+        for target in ("check", "lint", "static-check", "test", "build", "verify"):
+            for name, arguments, environment in (
+                ("none", (target,), None),
+                ("command", (target, "ROOT=/tmp/attacker-root"), None),
+                ("environment", (target,), {"ROOT": "/tmp/attacker-root"}),
+            ):
+                with self.subTest(target=target, override=name):
+                    result, checkout = self.run_make(*arguments, environment=environment)
+                    self.assertEqual(0, result.returncode, result.stderr)
+                    self.assertIn(checkout, result.stdout)
+                    self.assertNotIn("/tmp/attacker-root", result.stdout)
+
+    def test_command_line_makefile_list_override_fails_closed(self):
+        result, _ = self.run_make("check", "MAKEFILE_LIST=/tmp/attacker/Makefile")
+        self.assertNotEqual(0, result.returncode)
+        self.assertIn("MAKEFILE_LIST must not be overridden", result.stderr)
+
+    def test_environment_makefile_list_override_fails_closed(self):
+        result, _ = self.run_make(
+            "-e", "check", environment={"MAKEFILE_LIST": "/tmp/attacker/Makefile"}
+        )
+        self.assertNotEqual(0, result.returncode)
+        self.assertIn("MAKEFILE_LIST must not be overridden", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Preserve the complete checkout root when the SDK-free Makefile is invoked by an absolute path containing spaces, brackets, or apostrophes.

## Baseline

At exact default head `6d8510700234478a9b0ca782f01ed0374bf0c836`, `$(lastword $(MAKEFILE_LIST))` split a hostile filesystem path and silently redirected the static verifier to a fabricated path under the external caller.

## Improvements

- Derive `ROOT` from the complete loaded Makefile path using POSIX shell tools.
- Ignore command-line and environment `ROOT` overrides.
- Fail closed on command-line or environment-preferred `MAKEFILE_LIST` overrides.
- Run three SDK-free regression tests from every existing Make alias.
- Preserve all Swift, Xcode, podspec, scheme, and build-script behavior.

## Validation

- Python 3.12 root and external hostile-path gates: static baseline plus three tests passed.
- Python 3.14 root and external hostile-path gates: static baseline plus three tests passed.
- Warning-as-error Python compilation and `git diff --check`: passed.
- Current-tree gitleaks findings and staged high-confidence secret indicators: zero.
- No Xcode command, simulator, signing, or SystemConfiguration callback executed locally.

## Risk

The change is limited to SDK-free verification root discovery and regression coverage. It does not alter the Swift framework, 32-row reachability truth table, Xcode project, podspec, shared schemes, or build script.

## Follow-Ups

The PR remains for normal owner review and merge. Hosted macOS build/test remains authoritative for Apple toolchain behavior; local validation is static.
