### PR TITLE
ci: secure hosted validation and state Make boundary

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -17,6 +17,6 @@ jobs:
         with:
           persist-credentials: false
       - run: |
-          /usr/bin/python3 scripts/check-baseline.py
-          PYTHONDONTWRITEBYTECODE=1 /usr/bin/python3 -m unittest discover -s tests -p 'test_*.py'
+          /usr/bin/python3 -I -B scripts/check-baseline.py
+          /usr/bin/python3 -I -B -m unittest discover -s tests -p 'test_*.py'
           /bin/sh ./build.sh

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -16,5 +16,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           persist-credentials: false
-      - run: make check
-      - run: ./build.sh
+      - run: |
+          /usr/bin/python3 scripts/check-baseline.py
+          PYTHONDONTWRITEBYTECODE=1 /usr/bin/python3 -m unittest discover -s tests -p 'test_*.py'
+          /bin/sh ./build.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,9 @@ This repository maintains a small Swift wrapper around legacy
 - Run `./build.sh` on macOS to compile and execute the XCTest truth table.
 - Override `DESTINATION`, `SWIFT_VERSION`, or `IPHONEOS_DEPLOYMENT_TARGET` when
   validating with a different installed Xcode toolchain.
+- Treat Make aliases as convenience wrappers. The hosted direct chain remains
+  the pull-request authority, and local Make must fail closed for fake
+  `python3`, caller `SHELL`, and additional `-f` Makefile controls.
 
 ## Reachability Rules
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,9 +11,10 @@ This repository maintains a small Swift wrapper around legacy
 - Run `./build.sh` on macOS to compile and execute the XCTest truth table.
 - Override `DESTINATION`, `SWIFT_VERSION`, or `IPHONEOS_DEPLOYMENT_TARGET` when
   validating with a different installed Xcode toolchain.
-- Treat Make aliases as convenience wrappers. The hosted direct chain remains
-  the pull-request authority, and local Make must fail closed for fake
-  `python3`, caller `SHELL`, and additional `-f` Makefile controls.
+- Treat Make aliases as convenience wrappers for the checked-in Makefile. The
+  hosted direct workflow remains authoritative for pull requests; additional
+  `-f` Makefiles are caller-supplied Make programs outside the local Make trust
+  boundary.
 
 ## Reachability Rules
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,11 @@
 - Preserved the complete checkout root for absolute Makefile paths containing
   spaces, brackets, or apostrophes, and rejected `MAKEFILE_LIST` overrides.
 - Added three SDK-free regression tests across all six Make aliases.
+- Moved the hosted policy, Python test, and Xcode project bootstrap outside
+  mutable Make target, `ROOT`, and shell authority, with hostile hosted-equivalent
+  regression coverage and an explicit required-context trust boundary.
+- Required the exact hosted workflow and absolute Python, shell, and Xcode tool
+  paths, rejecting environment, step, shell, command, and fake-tool shadowing.
 
 ## 2026-06-19
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,9 +4,9 @@
 
 - Preserved the complete checkout root for absolute Makefile paths containing
   spaces, brackets, or apostrophes, and rejected `MAKEFILE_LIST` overrides.
-- Hardened every public Make alias with `/bin/sh`, `/usr/bin/python3`, and a
-  secondary-expansion guard that rejects additional `-f` Makefiles before a
-  replaced recipe can claim success.
+- Hardened every checked-in public Make alias with `/bin/sh` and
+  `/usr/bin/python3`, while documenting that additional `-f` Makefiles are
+  caller-supplied Make programs outside the local Make trust boundary.
 - Added three SDK-free regression tests across all six Make aliases.
 - Moved the hosted policy, Python test, and Xcode project bootstrap outside
   mutable Make target, `ROOT`, and shell authority, with hostile hosted-equivalent

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,9 @@
 
 - Preserved the complete checkout root for absolute Makefile paths containing
   spaces, brackets, or apostrophes, and rejected `MAKEFILE_LIST` overrides.
+- Hardened every public Make alias with `/bin/sh`, `/usr/bin/python3`, and a
+  secondary-expansion guard that rejects additional `-f` Makefiles before a
+  replaced recipe can claim success.
 - Added three SDK-free regression tests across all six Make aliases.
 - Moved the hosted policy, Python test, and Xcode project bootstrap outside
   mutable Make target, `ROOT`, and shell authority, with hostile hosted-equivalent

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,8 @@
   regression coverage and an explicit required-context trust boundary.
 - Required the exact hosted workflow and absolute Python, shell, and Xcode tool
   paths, rejecting environment, step, shell, command, and fake-tool shadowing.
+- Isolated local and hosted Python from `PYTHONPATH`, user-site startup code,
+  and bytecode writes so injected startup modules cannot claim successful gates.
 
 ## 2026-06-19
 

--- a/Makefile
+++ b/Makefile
@@ -18,5 +18,5 @@ check: verify
 lint test build verify: static-check
 
 static-check:
-	/usr/bin/python3 "$(ROOT)/scripts/check-baseline.py"
-	PYTHONDONTWRITEBYTECODE=1 /usr/bin/python3 -m unittest discover -s "$(ROOT)/tests" -p 'test_*.py'
+	/usr/bin/python3 -I -B "$(ROOT)/scripts/check-baseline.py"
+	/usr/bin/python3 -I -B -m unittest discover -s "$(ROOT)/tests" -p 'test_*.py'

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,25 @@
+override SHELL := /bin/sh
+override .SHELLFLAGS := -eu -c
+override HASH := \#
+
 ifneq ($(origin MAKEFILE_LIST),file)
 $(error MAKEFILE_LIST must not be overridden)
 endif
-override ROOT := $(shell path='$(subst ','"'"',$(MAKEFILE_LIST))'; path=$$(printf '%s\n' "$$path" | sed 's/^ //'); dirname -- "$$path")
+override MAKEFILE_PATH := $(shell path='$(subst ','"'"',$(MAKEFILE_LIST))'; first=$${path%"$${path$(HASH)?}"}; if [ "$$first" = " " ]; then path=$${path$(HASH)?}; fi; if [ -f "$$path" ]; then printf '%s\n' "$$path"; fi)
+ifeq ($(MAKEFILE_PATH),)
+$(error this Makefile must be invoked as the only Makefile)
+endif
+override ROOT := $(shell path='$(subst ','"'"',$(MAKEFILE_PATH))'; root=$${path%/*}; if [ "$$root" = "$$path" ]; then root=.; fi; if [ -z "$$root" ]; then root=/; fi; printf '%s\n' "$$root")
+override MAKEFILE_LIST_GUARD = $(if $(shell expected='$(subst ','"'"',$(MAKEFILE_PATH))'; actual='$(subst ','"'"',$(MAKEFILE_LIST))'; first=$${actual%"$${actual$(HASH)?}"}; if [ "$$first" = " " ]; then actual=$${actual$(HASH)?}; fi; if [ "$$actual" = "$$expected" ]; then :; else printf '%s\n' fail; fi),$(error additional Makefiles are not allowed; invoke this Makefile as the only Makefile))
 
 .PHONY: build check lint static-check test verify
+.SECONDEXPANSION:
+build check lint static-check test verify: $$(MAKEFILE_LIST_GUARD)
 
 check: verify
 
 lint test build verify: static-check
 
 static-check:
-	python3 "$(ROOT)/scripts/check-baseline.py"
-	PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s "$(ROOT)/tests" -p 'test_*.py'
+	/usr/bin/python3 "$(ROOT)/scripts/check-baseline.py"
+	PYTHONDONTWRITEBYTECODE=1 /usr/bin/python3 -m unittest discover -s "$(ROOT)/tests" -p 'test_*.py'

--- a/Makefile
+++ b/Makefile
@@ -7,14 +7,11 @@ $(error MAKEFILE_LIST must not be overridden)
 endif
 override MAKEFILE_PATH := $(shell path='$(subst ','"'"',$(MAKEFILE_LIST))'; first=$${path%"$${path$(HASH)?}"}; if [ "$$first" = " " ]; then path=$${path$(HASH)?}; fi; if [ -f "$$path" ]; then printf '%s\n' "$$path"; fi)
 ifeq ($(MAKEFILE_PATH),)
-$(error this Makefile must be invoked as the only Makefile)
+$(error this Makefile must be invoked directly as the checked-in Makefile)
 endif
 override ROOT := $(shell path='$(subst ','"'"',$(MAKEFILE_PATH))'; root=$${path%/*}; if [ "$$root" = "$$path" ]; then root=.; fi; if [ -z "$$root" ]; then root=/; fi; printf '%s\n' "$$root")
-override MAKEFILE_LIST_GUARD = $(if $(shell expected='$(subst ','"'"',$(MAKEFILE_PATH))'; actual='$(subst ','"'"',$(MAKEFILE_LIST))'; first=$${actual%"$${actual$(HASH)?}"}; if [ "$$first" = " " ]; then actual=$${actual$(HASH)?}; fi; if [ "$$actual" = "$$expected" ]; then :; else printf '%s\n' fail; fi),$(error additional Makefiles are not allowed; invoke this Makefile as the only Makefile))
 
 .PHONY: build check lint static-check test verify
-.SECONDEXPANSION:
-build check lint static-check test verify: $$(MAKEFILE_LIST_GUARD)
 
 check: verify
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
 - Absolute Makefile paths containing spaces, brackets, or apostrophes retain
   the complete checkout root. `ROOT` overrides are ignored, and attempts to
   override GNU Make's `MAKEFILE_LIST` metadata fail closed.
+- Local Make aliases pin `/bin/sh` shell execution and `/usr/bin/python3`, and
+  they fail closed when additional `-f` Makefiles are loaded before any public
+  alias recipe can claim success.
 - Run `./build.sh` when the required platform toolchain is installed. Override the simulator when needed:
 - The build script defaults `CODE_SIGNING_ALLOWED=NO` for simulator validation;
   override it only when intentionally testing signing behavior.
@@ -123,7 +126,10 @@ DESTINATION='platform=iOS Simulator,name=iPhone 16 Pro' ./build.sh
 - Hosted validation invokes `scripts/check-baseline.py`, the Python policy
   tests, and `build.sh` directly and in that order. It does not trust Make
   targets, `ROOT`, or caller shell settings as its bootstrap. Local Make aliases
-  remain convenience entrypoints and cannot authenticate a modified Makefile.
+  remain convenience entrypoints; they reject the reviewed fake `python3`,
+  command-line and `MAKEFLAGS` `SHELL`, `ROOT`, `MAKEFILE_LIST`, and additional
+  `-f` Makefile controls, but hosted validation is still the branch-protection
+  authority for pull requests.
 - The reviewed workflow is exact: one pinned credential-free checkout and one
   validation step, with no job/step environment, custom shell, extra step, or
   command addition. Hosted Python and shell entrypoints and `xcodebuild` use

--- a/README.md
+++ b/README.md
@@ -80,9 +80,10 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
 - Absolute Makefile paths containing spaces, brackets, or apostrophes retain
   the complete checkout root. `ROOT` overrides are ignored, and attempts to
   override GNU Make's `MAKEFILE_LIST` metadata fail closed.
-- Local Make aliases pin `/bin/sh` shell execution and `/usr/bin/python3` for
-  the checked-in Makefile. Additional `-f` Makefiles are caller-supplied Make
-  programs outside the local Make trust boundary.
+- Local Make aliases pin `/bin/sh` shell execution and isolated
+  `/usr/bin/python3 -I -B` processes for the checked-in Makefile. Additional
+  `-f` Makefiles are caller-supplied Make programs outside the local Make trust
+  boundary.
 - Run `./build.sh` when the required platform toolchain is installed. Override the simulator when needed:
 - The build script defaults `CODE_SIGNING_ALLOWED=NO` for simulator validation;
   override it only when intentionally testing signing behavior.
@@ -132,9 +133,9 @@ DESTINATION='platform=iOS Simulator,name=iPhone 16 Pro' ./build.sh
   for pull-request validation.
 - The reviewed workflow is exact: one pinned credential-free checkout and one
   validation step, with no job/step environment, custom shell, extra step, or
-  command addition. Hosted Python and shell entrypoints and `xcodebuild` use
-  absolute system paths, so repository or `PATH` shadowing cannot claim native
-  validation.
+  command addition. Hosted Python runs isolated from `PYTHONPATH` and user-site
+  startup code, while Python, shell, and `xcodebuild` use absolute system paths,
+  so repository or `PATH` shadowing cannot claim native validation.
 - The workflow is pull-request editable. Branch protection must continue to
   require the GitHub Actions `baseline` context, and reviewers must treat
   workflow changes as changes to verification authority. Repository code cannot

--- a/README.md
+++ b/README.md
@@ -80,9 +80,9 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
 - Absolute Makefile paths containing spaces, brackets, or apostrophes retain
   the complete checkout root. `ROOT` overrides are ignored, and attempts to
   override GNU Make's `MAKEFILE_LIST` metadata fail closed.
-- Local Make aliases pin `/bin/sh` shell execution and `/usr/bin/python3`, and
-  they fail closed when additional `-f` Makefiles are loaded before any public
-  alias recipe can claim success.
+- Local Make aliases pin `/bin/sh` shell execution and `/usr/bin/python3` for
+  the checked-in Makefile. Additional `-f` Makefiles are caller-supplied Make
+  programs outside the local Make trust boundary.
 - Run `./build.sh` when the required platform toolchain is installed. Override the simulator when needed:
 - The build script defaults `CODE_SIGNING_ALLOWED=NO` for simulator validation;
   override it only when intentionally testing signing behavior.
@@ -126,10 +126,10 @@ DESTINATION='platform=iOS Simulator,name=iPhone 16 Pro' ./build.sh
 - Hosted validation invokes `scripts/check-baseline.py`, the Python policy
   tests, and `build.sh` directly and in that order. It does not trust Make
   targets, `ROOT`, or caller shell settings as its bootstrap. Local Make aliases
-  remain convenience entrypoints; they reject the reviewed fake `python3`,
-  command-line and `MAKEFLAGS` `SHELL`, `ROOT`, `MAKEFILE_LIST`, and additional
-  `-f` Makefile controls, but hosted validation is still the branch-protection
-  authority for pull requests.
+  remain convenience entrypoints for the checked-in Makefile; they reject the
+  reviewed fake `python3`, command-line and `MAKEFLAGS` `SHELL`, `ROOT`, and
+  `MAKEFILE_LIST` controls. The hosted direct workflow remains authoritative
+  for pull-request validation.
 - The reviewed workflow is exact: one pinned credential-free checkout and one
   validation step, with no job/step environment, custom shell, extra step, or
   command addition. Hosted Python and shell entrypoints and `xcodebuild` use

--- a/README.md
+++ b/README.md
@@ -120,6 +120,19 @@ DESTINATION='platform=iOS Simulator,name=iPhone 16 Pro' ./build.sh
   `NetworkState.xcodeproj` without simulator execution, signing, pod
   publishing, or runtime connectivity checks. Checkout credentials are not
   persisted after source retrieval.
+- Hosted validation invokes `scripts/check-baseline.py`, the Python policy
+  tests, and `build.sh` directly and in that order. It does not trust Make
+  targets, `ROOT`, or caller shell settings as its bootstrap. Local Make aliases
+  remain convenience entrypoints and cannot authenticate a modified Makefile.
+- The reviewed workflow is exact: one pinned credential-free checkout and one
+  validation step, with no job/step environment, custom shell, extra step, or
+  command addition. Hosted Python and shell entrypoints and `xcodebuild` use
+  absolute system paths, so repository or `PATH` shadowing cannot claim native
+  validation.
+- The workflow is pull-request editable. Branch protection must continue to
+  require the GitHub Actions `baseline` context, and reviewers must treat
+  workflow changes as changes to verification authority. Repository code cannot
+  enforce those provider-side settings by itself.
 - `./build.sh` on macOS with Xcode
 - `pod spec lint NetworkState.podspec` when preparing CocoaPods release metadata
 - XCTest coverage includes reachable, connection-required, and unreachable reachability flag combinations.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -85,10 +85,12 @@ The hosted `baseline` job runs repository policy, Python tests, and the Xcode
 project check directly before entering any mutable Make target. This prevents
 duplicate `ROOT` assignments, recipe replacement, or caller shell settings from
 claiming successful policy validation. Local Make aliases remain convenience
-commands, not authority over arbitrary caller-supplied Make programs. They pin
-`/bin/sh` and `/usr/bin/python3`, and they fail closed for the reviewed fake
-`python3`, command-line and `MAKEFLAGS` `SHELL`, `ROOT`, `MAKEFILE_LIST`, and
-additional `-f` Makefile controls.
+commands for the checked-in Makefile, not authority over arbitrary
+caller-supplied Make programs. They pin `/bin/sh` and `/usr/bin/python3`, and
+they fail closed for the reviewed fake `python3`, command-line and `MAKEFLAGS`
+`SHELL`, `ROOT`, and `MAKEFILE_LIST` controls. Additional `-f` Makefiles are
+caller-supplied Make programs outside the local Make trust boundary; the hosted
+direct workflow remains authoritative for pull-request validation.
 
 The workflow contract permits only the pinned checkout and exact validation
 step, with no job/step environment, custom shell, extra step, or command

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -86,16 +86,18 @@ project check directly before entering any mutable Make target. This prevents
 duplicate `ROOT` assignments, recipe replacement, or caller shell settings from
 claiming successful policy validation. Local Make aliases remain convenience
 commands for the checked-in Makefile, not authority over arbitrary
-caller-supplied Make programs. They pin `/bin/sh` and `/usr/bin/python3`, and
-they fail closed for the reviewed fake `python3`, command-line and `MAKEFLAGS`
-`SHELL`, `ROOT`, and `MAKEFILE_LIST` controls. Additional `-f` Makefiles are
-caller-supplied Make programs outside the local Make trust boundary; the hosted
-direct workflow remains authoritative for pull-request validation.
+caller-supplied Make programs. They pin `/bin/sh` and isolated
+`/usr/bin/python3 -I -B` processes, and they fail closed for the reviewed fake
+`python3`, `PYTHONPATH` startup code, command-line and `MAKEFLAGS` `SHELL`,
+`ROOT`, and `MAKEFILE_LIST` controls. Additional `-f` Makefiles are caller-supplied
+Make programs outside the local Make trust boundary; the hosted direct workflow
+remains authoritative for pull-request validation.
 
 The workflow contract permits only the pinned checkout and exact validation
 step, with no job/step environment, custom shell, extra step, or command
-addition. Hosted Python, shell, and `xcodebuild` entrypoints use absolute system
-paths so checked-in or `PATH`-injected replacements cannot claim success.
+addition. Hosted Python runs isolated from `PYTHONPATH` and user-site startup
+code. Python, shell, and `xcodebuild` entrypoints use absolute system paths so
+checked-in or `PATH`-injected replacements cannot claim success.
 
 The workflow itself is pull-request editable. Branch protection must require
 the GitHub Actions `baseline` context, and workflow changes require review as

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -85,7 +85,10 @@ The hosted `baseline` job runs repository policy, Python tests, and the Xcode
 project check directly before entering any mutable Make target. This prevents
 duplicate `ROOT` assignments, recipe replacement, or caller shell settings from
 claiming successful policy validation. Local Make aliases remain convenience
-commands, not authority over an untrusted Makefile.
+commands, not authority over arbitrary caller-supplied Make programs. They pin
+`/bin/sh` and `/usr/bin/python3`, and they fail closed for the reviewed fake
+`python3`, command-line and `MAKEFLAGS` `SHELL`, `ROOT`, `MAKEFILE_LIST`, and
+additional `-f` Makefile controls.
 
 The workflow contract permits only the pinned checkout and exact validation
 step, with no job/step environment, custom shell, extra step, or command

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -81,6 +81,22 @@ repeatable.
 The hosted gate uses a credential-free checkout so its read-only token is not
 retained in the runner's Git configuration.
 
+The hosted `baseline` job runs repository policy, Python tests, and the Xcode
+project check directly before entering any mutable Make target. This prevents
+duplicate `ROOT` assignments, recipe replacement, or caller shell settings from
+claiming successful policy validation. Local Make aliases remain convenience
+commands, not authority over an untrusted Makefile.
+
+The workflow contract permits only the pinned checkout and exact validation
+step, with no job/step environment, custom shell, extra step, or command
+addition. Hosted Python, shell, and `xcodebuild` entrypoints use absolute system
+paths so checked-in or `PATH`-injected replacements cannot claim success.
+
+The workflow itself is pull-request editable. Branch protection must require
+the GitHub Actions `baseline` context, and workflow changes require review as
+changes to verification authority. Repository code cannot independently
+guarantee those provider-side settings.
+
 ## Safe Research Guidelines
 
 Good-faith research is welcome when it stays within these boundaries:

--- a/build.sh
+++ b/build.sh
@@ -9,13 +9,14 @@ SDK=${SDK:-iphonesimulator}
 SWIFT_VERSION=${SWIFT_VERSION:-5.0}
 IPHONEOS_DEPLOYMENT_TARGET=${IPHONEOS_DEPLOYMENT_TARGET:-12.0}
 CODE_SIGNING_ALLOWED=${CODE_SIGNING_ALLOWED:-NO}
+XCODEBUILD=/usr/bin/xcodebuild
 
-if ! command -v xcodebuild >/dev/null 2>&1; then
+if [ ! -x "$XCODEBUILD" ]; then
     echo "xcodebuild is required to run ${SCHEME}" >&2
     exit 127
 fi
 
-xcodebuild -project "${PROJECT}" \
+"$XCODEBUILD" -project "${PROJECT}" \
            -scheme "${SCHEME}" \
            -destination "${DESTINATION}" \
            -sdk "${SDK}" \

--- a/docs/plans/2026-06-21-spaced-makefile-path.md
+++ b/docs/plans/2026-06-21-spaced-makefile-path.md
@@ -14,6 +14,8 @@ the SDK-free verifier to a fabricated caller path.
 2. Preserve the authoritative root against command-line and environment input.
 3. Reject command-line or environment-preferred `MAKEFILE_LIST` overrides.
 4. Exercise all six Make aliases from an external working directory.
+5. Pin Make alias execution to `/bin/sh` and `/usr/bin/python3`, and reject
+   additional `-f` Makefiles before public alias recipes run.
 
 ## Verification
 
@@ -21,6 +23,8 @@ the SDK-free verifier to a fabricated caller path.
 - All six Make aliases retained the checkout with no override and with
   command-line or environment `ROOT` input.
 - Both tested `MAKEFILE_LIST` override paths failed closed.
+- Fake `python3` on `PATH`, command-line and `MAKEFLAGS` `SHELL`, and later
+  `-f` recipe replacement were rejected across all six Make aliases.
 - Static reachability, Xcode project, scheme, podspec, and workflow contracts
   remained green; no Apple build ran locally.
 

--- a/docs/plans/2026-06-21-spaced-makefile-path.md
+++ b/docs/plans/2026-06-21-spaced-makefile-path.md
@@ -14,8 +14,10 @@ the SDK-free verifier to a fabricated caller path.
 2. Preserve the authoritative root against command-line and environment input.
 3. Reject command-line or environment-preferred `MAKEFILE_LIST` overrides.
 4. Exercise all six Make aliases from an external working directory.
-5. Pin Make alias execution to `/bin/sh` and `/usr/bin/python3`, and reject
-   additional `-f` Makefiles before public alias recipes run.
+5. Pin checked-in Make alias execution to `/bin/sh` and `/usr/bin/python3`.
+6. Document that additional `-f` Makefiles are caller-supplied Make programs
+   outside the local Make trust boundary, and that the hosted direct workflow
+   remains authoritative.
 
 ## Verification
 
@@ -23,8 +25,8 @@ the SDK-free verifier to a fabricated caller path.
 - All six Make aliases retained the checkout with no override and with
   command-line or environment `ROOT` input.
 - Both tested `MAKEFILE_LIST` override paths failed closed.
-- Fake `python3` on `PATH`, command-line and `MAKEFLAGS` `SHELL`, and later
-  `-f` recipe replacement were rejected across all six Make aliases.
+- Fake `python3` on `PATH` plus command-line and `MAKEFLAGS` `SHELL` controls
+  were rejected across all six checked-in Make aliases.
 - Static reachability, Xcode project, scheme, podspec, and workflow contracts
   remained green; no Apple build ran locally.
 

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -20,14 +20,11 @@ $(error MAKEFILE_LIST must not be overridden)
 endif
 override MAKEFILE_PATH := $(shell path='$(subst ','"'"',$(MAKEFILE_LIST))'; first=$${path%"$${path$(HASH)?}"}; if [ "$$first" = " " ]; then path=$${path$(HASH)?}; fi; if [ -f "$$path" ]; then printf '%s\\n' "$$path"; fi)
 ifeq ($(MAKEFILE_PATH),)
-$(error this Makefile must be invoked as the only Makefile)
+$(error this Makefile must be invoked directly as the checked-in Makefile)
 endif
 override ROOT := $(shell path='$(subst ','"'"',$(MAKEFILE_PATH))'; root=$${path%/*}; if [ "$$root" = "$$path" ]; then root=.; fi; if [ -z "$$root" ]; then root=/; fi; printf '%s\\n' "$$root")
-override MAKEFILE_LIST_GUARD = $(if $(shell expected='$(subst ','"'"',$(MAKEFILE_PATH))'; actual='$(subst ','"'"',$(MAKEFILE_LIST))'; first=$${actual%"$${actual$(HASH)?}"}; if [ "$$first" = " " ]; then actual=$${actual$(HASH)?}; fi; if [ "$$actual" = "$$expected" ]; then :; else printf '%s\\n' fail; fi),$(error additional Makefiles are not allowed; invoke this Makefile as the only Makefile))
 
 .PHONY: build check lint static-check test verify
-.SECONDEXPANSION:
-build check lint static-check test verify: $$(MAKEFILE_LIST_GUARD)
 
 check: verify
 
@@ -312,12 +309,22 @@ def main() -> int:
     for phrase in [
         "`/bin/sh`",
         "`/usr/bin/python3`",
-        "additional `-f` Makefiles",
+        "additional `-f` Makefiles are caller-supplied Make programs",
+        "outside the local Make trust boundary",
+        "hosted direct workflow remains authoritative",
         "fake `python3`",
         "`MAKEFLAGS` `SHELL`",
     ]:
         if phrase not in make_contract_docs:
             failures.append(f"Make trust-boundary docs must mention {phrase}")
+    for overclaim in [
+        "reject additional `-f`",
+        "additional `-f` Makefiles before",
+        "recipe replacement were rejected",
+        "before a replaced recipe can claim success",
+    ]:
+        if overclaim in make_contract_docs:
+            failures.append(f"Make trust-boundary docs must not overclaim: {overclaim}")
     for phrase in [
         "make check",
         "pod spec lint",

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -2,9 +2,9 @@
 """Static baseline checks for the legacy NetworkState Swift framework."""
 
 from pathlib import Path
+import os
 import plistlib
 import re
-import shutil
 import subprocess
 import sys
 import xml.etree.ElementTree as ET
@@ -25,6 +25,29 @@ lint test build verify: static-check
 static-check:
 \tpython3 "$(ROOT)/scripts/check-baseline.py"
 \tPYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s "$(ROOT)/tests" -p 'test_*.py'
+"""
+EXPECTED_WORKFLOW = """name: Check
+on:
+  pull_request:
+  push:
+  workflow_dispatch:
+permissions:
+  contents: read
+concurrency:
+  group: check-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  baseline:
+    runs-on: macos-15
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
+      - run: |
+          /usr/bin/python3 scripts/check-baseline.py
+          PYTHONDONTWRITEBYTECODE=1 /usr/bin/python3 -m unittest discover -s tests -p 'test_*.py'
+          /bin/sh ./build.sh
 """
 REQUIRED = [
     ".gitignore",
@@ -182,7 +205,7 @@ def main() -> int:
         failures.append("placeholder XCTest methods must be replaced")
 
     build = read("build.sh")
-    for phrase in ["PROJECT=${PROJECT:-NetworkState.xcodeproj}", "SCHEME=${SCHEME:-NetworkStateTests}", "DESTINATION=${DESTINATION:-", "SWIFT_VERSION=${SWIFT_VERSION:-5.0}", "IPHONEOS_DEPLOYMENT_TARGET=${IPHONEOS_DEPLOYMENT_TARGET:-12.0}", "CODE_SIGNING_ALLOWED=${CODE_SIGNING_ALLOWED:-NO}", 'SWIFT_VERSION="${SWIFT_VERSION}"', 'IPHONEOS_DEPLOYMENT_TARGET="${IPHONEOS_DEPLOYMENT_TARGET}"', 'CODE_SIGNING_ALLOWED="${CODE_SIGNING_ALLOWED}"', "command -v xcodebuild"]:
+    for phrase in ["PROJECT=${PROJECT:-NetworkState.xcodeproj}", "SCHEME=${SCHEME:-NetworkStateTests}", "DESTINATION=${DESTINATION:-", "SWIFT_VERSION=${SWIFT_VERSION:-5.0}", "IPHONEOS_DEPLOYMENT_TARGET=${IPHONEOS_DEPLOYMENT_TARGET:-12.0}", "CODE_SIGNING_ALLOWED=${CODE_SIGNING_ALLOWED:-NO}", "XCODEBUILD=/usr/bin/xcodebuild", '[ ! -x "$XCODEBUILD" ]', 'SWIFT_VERSION="${SWIFT_VERSION}"', 'IPHONEOS_DEPLOYMENT_TARGET="${IPHONEOS_DEPLOYMENT_TARGET}"', 'CODE_SIGNING_ALLOWED="${CODE_SIGNING_ALLOWED}"']:
         if phrase not in build:
             failures.append(f"build.sh must include {phrase}")
     if "function " in build:
@@ -420,11 +443,11 @@ def main() -> int:
         "runs-on: macos-15",
         "timeout-minutes: 10",
         "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10",
-        "run: make check",
-        "run: ./build.sh",
     ]:
         if expected not in workflow:
             failures.append(f"Check workflow must keep {expected}")
+    if workflow != EXPECTED_WORKFLOW:
+        failures.append("Check workflow must preserve the exact reviewed workflow")
 
     checkout_plan = read("docs/plans/2026-06-12-checkout-credential-boundary.md")
     if (
@@ -465,9 +488,10 @@ def main() -> int:
         if phrase not in guidance:
             failures.append(f"repository guidance must mention {phrase}")
 
-    if shutil.which("xcodebuild"):
+    xcodebuild = Path("/usr/bin/xcodebuild")
+    if xcodebuild.is_file() and os.access(xcodebuild, os.X_OK):
         result = subprocess.run(
-            ["xcodebuild", "-list", "-project", "NetworkState.xcodeproj"],
+            [str(xcodebuild), "-list", "-project", "NetworkState.xcodeproj"],
             cwd=ROOT,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.PIPE,

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -31,8 +31,8 @@ check: verify
 lint test build verify: static-check
 
 static-check:
-\t/usr/bin/python3 "$(ROOT)/scripts/check-baseline.py"
-\tPYTHONDONTWRITEBYTECODE=1 /usr/bin/python3 -m unittest discover -s "$(ROOT)/tests" -p 'test_*.py'
+\t/usr/bin/python3 -I -B "$(ROOT)/scripts/check-baseline.py"
+\t/usr/bin/python3 -I -B -m unittest discover -s "$(ROOT)/tests" -p 'test_*.py'
 """
 EXPECTED_WORKFLOW = """name: Check
 on:
@@ -53,8 +53,8 @@ jobs:
         with:
           persist-credentials: false
       - run: |
-          /usr/bin/python3 scripts/check-baseline.py
-          PYTHONDONTWRITEBYTECODE=1 /usr/bin/python3 -m unittest discover -s tests -p 'test_*.py'
+          /usr/bin/python3 -I -B scripts/check-baseline.py
+          /usr/bin/python3 -I -B -m unittest discover -s tests -p 'test_*.py'
           /bin/sh ./build.sh
 """
 REQUIRED = [

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -11,20 +11,31 @@ import xml.etree.ElementTree as ET
 
 
 ROOT = Path(__file__).resolve().parents[1]
-EXPECTED_MAKEFILE = """ifneq ($(origin MAKEFILE_LIST),file)
+EXPECTED_MAKEFILE = """override SHELL := /bin/sh
+override .SHELLFLAGS := -eu -c
+override HASH := \\#
+
+ifneq ($(origin MAKEFILE_LIST),file)
 $(error MAKEFILE_LIST must not be overridden)
 endif
-override ROOT := $(shell path='$(subst ','"'"',$(MAKEFILE_LIST))'; path=$$(printf '%s\\n' "$$path" | sed 's/^ //'); dirname -- "$$path")
+override MAKEFILE_PATH := $(shell path='$(subst ','"'"',$(MAKEFILE_LIST))'; first=$${path%"$${path$(HASH)?}"}; if [ "$$first" = " " ]; then path=$${path$(HASH)?}; fi; if [ -f "$$path" ]; then printf '%s\\n' "$$path"; fi)
+ifeq ($(MAKEFILE_PATH),)
+$(error this Makefile must be invoked as the only Makefile)
+endif
+override ROOT := $(shell path='$(subst ','"'"',$(MAKEFILE_PATH))'; root=$${path%/*}; if [ "$$root" = "$$path" ]; then root=.; fi; if [ -z "$$root" ]; then root=/; fi; printf '%s\\n' "$$root")
+override MAKEFILE_LIST_GUARD = $(if $(shell expected='$(subst ','"'"',$(MAKEFILE_PATH))'; actual='$(subst ','"'"',$(MAKEFILE_LIST))'; first=$${actual%"$${actual$(HASH)?}"}; if [ "$$first" = " " ]; then actual=$${actual$(HASH)?}; fi; if [ "$$actual" = "$$expected" ]; then :; else printf '%s\\n' fail; fi),$(error additional Makefiles are not allowed; invoke this Makefile as the only Makefile))
 
 .PHONY: build check lint static-check test verify
+.SECONDEXPANSION:
+build check lint static-check test verify: $$(MAKEFILE_LIST_GUARD)
 
 check: verify
 
 lint test build verify: static-check
 
 static-check:
-\tpython3 "$(ROOT)/scripts/check-baseline.py"
-\tPYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s "$(ROOT)/tests" -p 'test_*.py'
+\t/usr/bin/python3 "$(ROOT)/scripts/check-baseline.py"
+\tPYTHONDONTWRITEBYTECODE=1 /usr/bin/python3 -m unittest discover -s "$(ROOT)/tests" -p 'test_*.py'
 """
 EXPECTED_WORKFLOW = """name: Check
 on:
@@ -288,6 +299,25 @@ def main() -> int:
         "all six Make aliases",
     ]):
         failures.append("spaced Makefile path plan must preserve hostile-path and override verification")
+    make_contract_docs = "\n".join(
+        read(path)
+        for path in [
+            "README.md",
+            "SECURITY.md",
+            "AGENTS.md",
+            "CHANGES.md",
+            "docs/plans/2026-06-21-spaced-makefile-path.md",
+        ]
+    )
+    for phrase in [
+        "`/bin/sh`",
+        "`/usr/bin/python3`",
+        "additional `-f` Makefiles",
+        "fake `python3`",
+        "`MAKEFLAGS` `SHELL`",
+    ]:
+        if phrase not in make_contract_docs:
+            failures.append(f"Make trust-boundary docs must mention {phrase}")
     for phrase in [
         "make check",
         "pod spec lint",

--- a/tests/test_makefile_root.py
+++ b/tests/test_makefile_root.py
@@ -184,6 +184,145 @@ class MakefileRootTests(unittest.TestCase):
             self.assertIn("REAL_PROJECT_CHECK", result.stdout)
             self.assertFalse(fake_shell_log.exists())
 
+    def test_make_aliases_do_not_trust_python_from_path(self):
+        makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
+        targets = ("check", "lint", "static-check", "test", "build", "verify")
+        with tempfile.TemporaryDirectory(prefix="networkstate fake python ") as directory:
+            root = Path(directory)
+            checkout = root / "checkout"
+            external = root / "external caller"
+            tools = root / "tools"
+            checkout.mkdir()
+            external.mkdir()
+            tools.mkdir()
+            self.write_hosted_fixture(checkout, makefile)
+            fake_python_log = root / "fake-python-ran"
+            fake_python = tools / "python3"
+            fake_python.write_text(
+                "#!/bin/sh\n"
+                f"printf 'fake python %s\\n' \"$*\" >> {str(fake_python_log)!r}\n"
+                "exit 0\n",
+                encoding="utf-8",
+            )
+            fake_python.chmod(0o755)
+            environment = os.environ.copy()
+            environment["PATH"] = str(tools) + os.pathsep + environment["PATH"]
+
+            for target in targets:
+                with self.subTest(target=target):
+                    if fake_python_log.exists():
+                        fake_python_log.unlink()
+                    result = subprocess.run(
+                        [
+                            "make",
+                            "--no-print-directory",
+                            "-f",
+                            str(checkout / "Makefile"),
+                            target,
+                        ],
+                        cwd=external,
+                        env=environment,
+                        capture_output=True,
+                        text=True,
+                        check=False,
+                    )
+
+                    self.assertEqual(0, result.returncode, result.stderr)
+                    self.assertIn("REAL_HOSTED_POLICY", result.stdout)
+                    self.assertIn("REAL_PYTHON_TESTS", result.stdout)
+                    self.assertFalse(fake_python_log.exists(), fake_python_log.read_text() if fake_python_log.exists() else "")
+
+    def test_make_aliases_do_not_trust_command_line_or_makeflags_shell(self):
+        makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
+        targets = ("check", "lint", "static-check", "test", "build", "verify")
+        with tempfile.TemporaryDirectory(prefix="networkstate-fake-shell-") as directory:
+            root = Path(directory)
+            checkout = root / "checkout"
+            external = root / "external caller"
+            tools = root / "tools"
+            checkout.mkdir()
+            external.mkdir()
+            tools.mkdir()
+            self.write_hosted_fixture(checkout, makefile)
+            fake_shell = tools / "fake-shell"
+            fake_shell.write_text(
+                "#!/bin/sh\n"
+                "printf 'fake shell %s\\n' \"$*\" >> \"$FAKE_SHELL_LOG\"\n"
+                "exit 0\n",
+                encoding="utf-8",
+            )
+            fake_shell.chmod(0o755)
+
+            for target in targets:
+                for channel in ("command line", "MAKEFLAGS"):
+                    with self.subTest(target=target, channel=channel):
+                        fake_shell_log = root / f"fake-shell-{target}-{channel.replace(' ', '-')}.log"
+                        environment = os.environ.copy()
+                        environment["FAKE_SHELL_LOG"] = str(fake_shell_log)
+                        arguments = [
+                            "make",
+                            "--no-print-directory",
+                            "-f",
+                            str(checkout / "Makefile"),
+                            target,
+                        ]
+                        if channel == "command line":
+                            arguments.append(f"SHELL={fake_shell}")
+                        else:
+                            environment["MAKEFLAGS"] = f"SHELL={fake_shell}"
+
+                        result = subprocess.run(
+                            arguments,
+                            cwd=external,
+                            env=environment,
+                            capture_output=True,
+                            text=True,
+                            check=False,
+                        )
+
+                        self.assertEqual(0, result.returncode, result.stderr)
+                        self.assertIn("REAL_HOSTED_POLICY", result.stdout)
+                        self.assertIn("REAL_PYTHON_TESTS", result.stdout)
+                        self.assertFalse(fake_shell_log.exists(), fake_shell_log.read_text() if fake_shell_log.exists() else "")
+
+    def test_later_makefile_recipe_replacement_fails_before_public_aliases(self):
+        makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
+        targets = ("check", "lint", "static-check", "test", "build", "verify")
+        with tempfile.TemporaryDirectory(prefix="networkstate later makefile ") as directory:
+            root = Path(directory)
+            for target in targets:
+                with self.subTest(target=target):
+                    checkout = root / target
+                    external = checkout / "external caller"
+                    checkout.mkdir()
+                    external.mkdir()
+                    self.write_hosted_fixture(checkout, makefile)
+                    later_makefile = checkout / "later.mk"
+                    later_makefile.write_text(
+                        f"{target}:\n\t@echo LATER_RECIPE_{target}\n",
+                        encoding="utf-8",
+                    )
+
+                    result = subprocess.run(
+                        [
+                            "make",
+                            "--no-print-directory",
+                            "-f",
+                            str(checkout / "Makefile"),
+                            "-f",
+                            str(later_makefile),
+                            target,
+                        ],
+                        cwd=external,
+                        capture_output=True,
+                        text=True,
+                        check=False,
+                    )
+
+                    self.assertNotEqual(0, result.returncode, result.stdout)
+                    self.assertIn("additional Makefiles are not allowed", result.stderr)
+                    self.assertNotIn(f"LATER_RECIPE_{target}", result.stdout)
+
     def test_workflow_rejects_authority_mutations(self):
         workflow = (ROOT / ".github/workflows/check.yml").read_text(encoding="utf-8")
         mutations = {

--- a/tests/test_makefile_root.py
+++ b/tests/test_makefile_root.py
@@ -232,6 +232,54 @@ class MakefileRootTests(unittest.TestCase):
                     self.assertIn("REAL_PYTHON_TESTS", result.stdout)
                     self.assertFalse(fake_python_log.exists(), fake_python_log.read_text() if fake_python_log.exists() else "")
 
+    def test_python_entrypoints_ignore_pythonpath_startup_code(self):
+        makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
+        with tempfile.TemporaryDirectory(prefix="networkstate pythonpath ") as directory:
+            root = Path(directory)
+            checkout = root / "checkout"
+            startup = root / "startup"
+            checkout.mkdir()
+            startup.mkdir()
+            self.write_hosted_fixture(checkout, makefile)
+            marker = root / "sitecustomize-ran"
+            (startup / "sitecustomize.py").write_text(
+                "import os\n"
+                "from pathlib import Path\n"
+                "Path(os.environ['NETWORKSTATE_STARTUP_MARKER']).write_text('ran\\n')\n"
+                "os._exit(0)\n",
+                encoding="utf-8",
+            )
+            environment = os.environ.copy()
+            environment["PYTHONPATH"] = str(startup)
+            environment["NETWORKSTATE_STARTUP_MARKER"] = str(marker)
+
+            make_result = subprocess.run(
+                ["make", "--no-print-directory", "-f", str(checkout / "Makefile"), "check"],
+                cwd=root,
+                env=environment,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(0, make_result.returncode, make_result.stderr)
+            self.assertIn("REAL_HOSTED_POLICY", make_result.stdout)
+            self.assertIn("REAL_PYTHON_TESTS", make_result.stdout)
+            self.assertFalse(marker.exists())
+
+            hosted_result = subprocess.run(
+                ["/bin/sh", "-e", "-c", self.hosted_commands()],
+                cwd=checkout,
+                env=environment,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(0, hosted_result.returncode, hosted_result.stderr)
+            self.assertIn("REAL_HOSTED_POLICY", hosted_result.stdout)
+            self.assertIn("REAL_PYTHON_TESTS", hosted_result.stdout)
+            self.assertIn("REAL_PROJECT_CHECK", hosted_result.stdout)
+            self.assertFalse(marker.exists())
+
     def test_make_aliases_do_not_trust_command_line_or_makeflags_shell(self):
         makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
         targets = ("check", "lint", "static-check", "test", "build", "verify")
@@ -374,7 +422,7 @@ class MakefileRootTests(unittest.TestCase):
                         mutated_workflow, encoding="utf-8"
                     )
                     result = subprocess.run(
-                        ["/usr/bin/python3", "scripts/check-baseline.py"],
+                        ["/usr/bin/python3", "-I", "-B", "scripts/check-baseline.py"],
                         cwd=checkout,
                         capture_output=True,
                         text=True,

--- a/tests/test_makefile_root.py
+++ b/tests/test_makefile_root.py
@@ -285,43 +285,60 @@ class MakefileRootTests(unittest.TestCase):
                         self.assertIn("REAL_PYTHON_TESTS", result.stdout)
                         self.assertFalse(fake_shell_log.exists(), fake_shell_log.read_text() if fake_shell_log.exists() else "")
 
-    def test_later_makefile_recipe_replacement_fails_before_public_aliases(self):
+    def test_contract_keeps_additional_makefiles_outside_local_make_trust_boundary(self):
         makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
-        targets = ("check", "lint", "static-check", "test", "build", "verify")
-        with tempfile.TemporaryDirectory(prefix="networkstate later makefile ") as directory:
-            root = Path(directory)
-            for target in targets:
-                with self.subTest(target=target):
-                    checkout = root / target
-                    external = checkout / "external caller"
-                    checkout.mkdir()
-                    external.mkdir()
-                    self.write_hosted_fixture(checkout, makefile)
-                    later_makefile = checkout / "later.mk"
-                    later_makefile.write_text(
-                        f"{target}:\n\t@echo LATER_RECIPE_{target}\n",
-                        encoding="utf-8",
-                    )
+        self.assertNotIn(".SECONDEXPANSION", makefile)
+        self.assertNotIn("MAKEFILE_LIST_GUARD", makefile)
 
-                    result = subprocess.run(
-                        [
-                            "make",
-                            "--no-print-directory",
-                            "-f",
-                            str(checkout / "Makefile"),
-                            "-f",
-                            str(later_makefile),
-                            target,
-                        ],
-                        cwd=external,
-                        capture_output=True,
-                        text=True,
-                        check=False,
-                    )
+        docs = "\n".join(
+            (ROOT / path).read_text(encoding="utf-8")
+            for path in [
+                "README.md",
+                "SECURITY.md",
+                "AGENTS.md",
+                "CHANGES.md",
+                "docs/plans/2026-06-21-spaced-makefile-path.md",
+            ]
+        )
+        for phrase in [
+            "additional `-f` Makefiles are caller-supplied Make programs",
+            "outside the local Make trust boundary",
+            "hosted direct workflow remains authoritative",
+        ]:
+            self.assertIn(phrase, docs)
+        for overclaim in [
+            "reject additional `-f`",
+            "additional `-f` Makefiles before",
+            "recipe replacement were rejected",
+            "before a replaced recipe can claim success",
+        ]:
+            self.assertNotIn(overclaim, docs)
 
-                    self.assertNotEqual(0, result.returncode, result.stdout)
-                    self.assertIn("additional Makefiles are not allowed", result.stderr)
-                    self.assertNotIn(f"LATER_RECIPE_{target}", result.stdout)
+    def test_hosted_direct_chain_rejects_repository_mutation_before_make(self):
+        makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
+        commands = self.hosted_commands()
+        self.assertNotIn("make ", commands)
+        self.assertNotIn("make\n", commands)
+        with tempfile.TemporaryDirectory(prefix="networkstate hosted direct mutation ") as directory:
+            checkout = Path(directory) / "checkout"
+            checkout.mkdir()
+            self.write_hosted_fixture(
+                checkout,
+                makefile + "\ncheck:\n\t@echo MAKE_WOULD_CLAIM_SUCCESS\n",
+            )
+
+            result = subprocess.run(
+                ["/bin/sh", "-e", "-c", commands],
+                cwd=checkout,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertNotEqual(0, result.returncode, result.stdout)
+            self.assertIn("REAL_HOSTED_POLICY", result.stdout)
+            self.assertIn("hosted policy rejected Makefile mutation", result.stderr)
+            self.assertNotIn("MAKE_WOULD_CLAIM_SUCCESS", result.stdout)
 
     def test_workflow_rejects_authority_mutations(self):
         workflow = (ROOT / ".github/workflows/check.yml").read_text(encoding="utf-8")

--- a/tests/test_makefile_root.py
+++ b/tests/test_makefile_root.py
@@ -1,5 +1,6 @@
 import os
 from pathlib import Path
+import re
 import shutil
 import subprocess
 import tempfile
@@ -10,6 +11,57 @@ ROOT = Path(__file__).resolve().parents[1]
 
 
 class MakefileRootTests(unittest.TestCase):
+    def hosted_commands(self, root=ROOT):
+        workflow = (root / ".github/workflows/check.yml").read_text(encoding="utf-8")
+        commands = []
+        lines = workflow.splitlines()
+        index = 0
+        while index < len(lines):
+            match = re.match(r"^      - run: (.*)$", lines[index])
+            if not match:
+                index += 1
+                continue
+            value = match.group(1)
+            if value != "|":
+                commands.append(value)
+                index += 1
+                continue
+            index += 1
+            block = []
+            while index < len(lines) and lines[index].startswith("          "):
+                block.append(lines[index][10:])
+                index += 1
+            commands.append("\n".join(block))
+        self.assertTrue(commands, workflow)
+        return "\n".join(commands)
+
+    def write_hosted_fixture(self, root, makefile):
+        (root / "scripts").mkdir(parents=True)
+        (root / "tests").mkdir()
+        (root / "Makefile").write_text(makefile, encoding="utf-8")
+        expected_makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
+        (root / "scripts/check-baseline.py").write_text(
+            "from pathlib import Path\n"
+            "import sys\n"
+            "root = Path(__file__).resolve().parents[1]\n"
+            "print('REAL_HOSTED_POLICY')\n"
+            f"expected = {expected_makefile!r}\n"
+            "if (root / 'Makefile').read_text(encoding='utf-8') != expected:\n"
+            "    print('hosted policy rejected Makefile mutation', file=sys.stderr)\n"
+            "    raise SystemExit(1)\n",
+            encoding="utf-8",
+        )
+        (root / "tests/test_smoke.py").write_text(
+            "import unittest\n\n"
+            "class Smoke(unittest.TestCase):\n"
+            "    def test_real_python_tests(self):\n"
+            "        print('REAL_PYTHON_TESTS')\n"
+            "        self.assertTrue(True)\n",
+            encoding="utf-8",
+        )
+        (root / "build.sh").write_text("#!/bin/sh\necho REAL_PROJECT_CHECK\n", encoding="utf-8")
+        (root / "build.sh").chmod(0o755)
+
     def run_make(self, *arguments, environment=None):
         with tempfile.TemporaryDirectory(prefix="networkstate make path ") as directory:
             root = Path(directory)
@@ -56,6 +108,170 @@ class MakefileRootTests(unittest.TestCase):
         )
         self.assertNotEqual(0, result.returncode)
         self.assertIn("MAKEFILE_LIST must not be overridden", result.stderr)
+
+    def test_hosted_sequence_rejects_make_authority_bypasses(self):
+        makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
+        mutations = {
+            "duplicate global root": "\noverride ROOT := $(CURDIR)/fake-root\n",
+            "duplicate target root": "\nstatic-check: override ROOT := $(CURDIR)/fake-root\n",
+            "recipe override": "\nstatic-check:\n\t@echo FAKE_CHECK_OVERRIDE\n",
+            "combined recipe and root": (
+                "\nstatic-check:\n\t@echo FAKE_CHECK_OVERRIDE\n"
+                "\ntest: override ROOT := $(CURDIR)/fake-root\n"
+            ),
+        }
+        with tempfile.TemporaryDirectory(prefix="networkstate hosted policy ") as directory:
+            temporary_root = Path(directory)
+            for name, mutation in mutations.items():
+                with self.subTest(name=name):
+                    checkout = temporary_root / name
+                    checkout.mkdir()
+                    self.write_hosted_fixture(checkout, makefile + mutation)
+                    fake_root = checkout / "fake-root"
+                    fake_root.mkdir()
+                    (fake_root / "build.sh").write_text(
+                        "#!/bin/sh\necho FAKE_PROJECT_CHECK\n", encoding="utf-8"
+                    )
+                    (fake_root / "build.sh").chmod(0o755)
+
+                    result = subprocess.run(
+                        ["/bin/sh", "-e", "-c", self.hosted_commands()],
+                        cwd=checkout,
+                        capture_output=True,
+                        text=True,
+                        check=False,
+                    )
+
+                    self.assertNotEqual(0, result.returncode, result.stdout)
+                    self.assertIn("REAL_HOSTED_POLICY", result.stdout)
+                    self.assertIn("hosted policy rejected Makefile mutation", result.stderr)
+                    self.assertNotIn("FAKE_CHECK_OVERRIDE", result.stdout)
+                    self.assertNotIn("FAKE_PROJECT_CHECK", result.stdout)
+
+    def test_hosted_sequence_ignores_caller_shell(self):
+        makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
+        with tempfile.TemporaryDirectory(prefix="networkstate hosted shell ") as directory, tempfile.TemporaryDirectory(
+            prefix="networkstate-shell-"
+        ) as tool_directory:
+            checkout = Path(directory) / "checkout with spaces 'quote' [hostile]"
+            checkout.mkdir()
+            self.write_hosted_fixture(checkout, makefile)
+            fake_shell_log = Path(tool_directory) / "fake-shell-ran"
+            fake_shell = Path(tool_directory) / "fake-shell"
+            fake_shell.write_text(
+                "#!/bin/sh\n"
+                f"printf invoked > {str(fake_shell_log)!r}\n"
+                "exit 0\n",
+                encoding="utf-8",
+            )
+            fake_shell.chmod(0o755)
+            environment = os.environ.copy()
+            environment["SHELL"] = str(fake_shell)
+            environment["MAKEFLAGS"] = "SHELL={}".format(fake_shell)
+
+            result = subprocess.run(
+                ["/bin/sh", "-e", "-c", self.hosted_commands()],
+                cwd=checkout,
+                env=environment,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(0, result.returncode, result.stderr)
+            self.assertIn("REAL_HOSTED_POLICY", result.stdout)
+            self.assertIn("REAL_PYTHON_TESTS", result.stdout)
+            self.assertIn("REAL_PROJECT_CHECK", result.stdout)
+            self.assertFalse(fake_shell_log.exists())
+
+    def test_workflow_rejects_authority_mutations(self):
+        workflow = (ROOT / ".github/workflows/check.yml").read_text(encoding="utf-8")
+        mutations = {
+            "job environment": workflow.replace(
+                "    runs-on: macos-15\n",
+                "    runs-on: macos-15\n    env:\n      PATH: .:${{ env.PATH }}\n",
+            ),
+            "step environment": workflow.replace(
+                "      - run: |\n",
+                "      - env:\n          PATH: .:${{ env.PATH }}\n        run: |\n",
+            ),
+            "extra step": workflow + "      - run: echo extra\n",
+            "custom shell": workflow.replace(
+                "      - run: |\n",
+                "      - shell: python\n        run: |\n",
+            ),
+            "command addition": workflow.replace(
+                "          /bin/sh ./build.sh\n",
+                "          echo injected\n          /bin/sh ./build.sh\n",
+            ),
+        }
+        with tempfile.TemporaryDirectory(prefix="networkstate workflow policy ") as directory:
+            for name, mutated_workflow in mutations.items():
+                with self.subTest(name=name):
+                    checkout = Path(directory) / name
+                    shutil.copytree(
+                        ROOT,
+                        checkout,
+                        ignore=shutil.ignore_patterns(".git", "__pycache__", "*.pyc"),
+                    )
+                    (checkout / ".github/workflows/check.yml").write_text(
+                        mutated_workflow, encoding="utf-8"
+                    )
+                    result = subprocess.run(
+                        ["/usr/bin/python3", "scripts/check-baseline.py"],
+                        cwd=checkout,
+                        capture_output=True,
+                        text=True,
+                        check=False,
+                    )
+                    self.assertNotEqual(0, result.returncode, result.stdout)
+                    self.assertIn("exact reviewed workflow", result.stderr)
+
+    def test_hosted_sequence_rejects_checked_in_native_tools(self):
+        with tempfile.TemporaryDirectory(prefix="networkstate hosted tools ") as directory:
+            checkout = Path(directory) / "checkout"
+            shutil.copytree(
+                ROOT,
+                checkout,
+                ignore=shutil.ignore_patterns(".git", "__pycache__", "*.pyc"),
+            )
+            workflow_path = checkout / ".github/workflows/check.yml"
+            malicious_workflow = workflow_path.read_text(encoding="utf-8").replace(
+                "    runs-on: macos-15\n",
+                "    runs-on: macos-15\n    env:\n      PATH: .:${{ env.PATH }}\n",
+            )
+            workflow_path.write_text(malicious_workflow, encoding="utf-8")
+            (checkout / "tests/test_makefile_root.py").write_text(
+                "import unittest\n\n"
+                "class Smoke(unittest.TestCase):\n"
+                "    def test_policy_completed(self): self.assertTrue(True)\n",
+                encoding="utf-8",
+            )
+            fake_tool_log = checkout / "fake-native-tool-ran"
+            for tool in ("xcrun", "xcodebuild"):
+                tool_path = checkout / tool
+                tool_path.write_text(
+                    "#!/bin/sh\n"
+                    f"printf '%s\\n' {tool} >> {str(fake_tool_log)!r}\n"
+                    "exit 0\n",
+                    encoding="utf-8",
+                )
+                tool_path.chmod(0o755)
+            environment = os.environ.copy()
+            environment["PATH"] = ".{}{}".format(os.pathsep, environment["PATH"])
+
+            result = subprocess.run(
+                ["/bin/sh", "-e", "-c", self.hosted_commands(checkout)],
+                cwd=checkout,
+                env=environment,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertNotEqual(0, result.returncode, result.stdout)
+            self.assertIn("exact reviewed workflow", result.stderr)
+            self.assertFalse(fake_tool_log.exists())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Keep hosted policy, Python tests, and native build outside mutable Make target authority.
- Pin shell, Python, and Xcode entrypoints to absolute system tools.
- Run local and hosted Python validation with `-I -B`, excluding caller `PYTHONPATH`, user-site startup code, and bytecode writes.
- Document additional `-f` Makefiles as caller-supplied programs outside the local Make trust boundary.
- Preserve the public reachability API and application behavior.

## Baseline

The validation chain could be influenced by caller-controlled shell, PATH, Python startup, or Make authority. A malicious `sitecustomize.py` could previously make `make check` return success without executing the intended policy and tests, and hosted validation delegated too much authority to mutable Make targets.

## Improvements

The final stack uses absolute system entrypoints, isolated Python execution, a direct hosted policy/test/native-build sequence, exact workflow contracts, and adversarial tests for Make, environment, workflow, and checked-in native-tool bypasses.

## Validation

Exact head `3a3209984fc05669ca57c9182e95bad2e0da6e30` passed locally:

- 12 Python authority tests, including a `sitecustomize.py` proof that previously made `make check` return 0 without running policy or tests
- All six Make aliases and the full `make check` gate under hostile `PYTHONPATH`
- Fake-PATH Python, command/`MAKEFLAGS` shell, `ROOT`, `MAKEFILE_LIST`, workflow, and native-tool probes
- Native simulator build and 10 XCTest cases with zero failures
- Shell/Python syntax, `git diff --check`, and `git fsck`

The requested head `d48a66f210470e02d4292d3e710da2fa30fbc35d` was verified before repair. The merged exact head subsequently passed hosted validation.

## Risk

This changes validation authority and documentation rather than the public reachability API. Local Linux environments still cannot reproduce SystemConfiguration, simulator, signing, carrier, captive-portal, or device behavior; hosted macOS remains required.

## Follow-Ups

Keep the direct hosted sequence, absolute tool paths, isolated Python flags, checkout credential boundary, and protected `baseline` context intact. Future Swift behavior changes require native XCTest evidence on the exact head.
