### PR TITLE
docs: clarify NetworkState CocoaPods source

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,5 +30,7 @@ This repository maintains a small Swift wrapper around legacy
 
 - Preserve the public Boolean API and fixture evaluator unless a reviewed
   compatibility change explicitly replaces them.
+- Do not recommend the historical `0.0.2` tag as current source; package
+  guidance must distinguish mutable branch installs from reviewed commit pins.
 - Keep checkout credentials disabled and the single hosted workflow intact.
 - Record skipped device, carrier, captive-portal, and live-service validation.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -48,8 +48,13 @@ implementation.
 - Python bytecode compilation and `git diff --check` passed. Validation-created
   bytecode plus the empty file produced by the misquoted mutation command were
   removed before review.
-- Local Xcode remained unavailable and skipped truthfully. Hosted Xcode tests
-  and exact-head review remain pending.
+- First exact-head Codex review — clean on
+  `148459249eebc876cb0af121d2ef2c1d2615fd0e` with no actionable findings.
+- First hosted pull-request run — macOS baseline, framework build, XCTest,
+  CodeQL Actions, and CodeQL Python passed. A duplicate push-triggered baseline
+  for the same head was canceled after the pull-request run became authoritative.
+- Local Xcode remained unavailable and skipped truthfully. Final exact-head
+  review and hosted reruns remain required after this evidence update.
 
 ### Bugs / findings
 
@@ -63,8 +68,8 @@ implementation.
 
 ### Next action
 
-- Open the pull request, run exact-head review, and require hosted baseline and
-  Xcode success before merge.
+- Re-run exact-head review and require final hosted baseline and CodeQL success
+  before merge.
 
 ## 2026-06-21
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -58,6 +58,12 @@ implementation.
 - Review fix — parse Ruby code blocks into `NetworkState` pod declarations,
   normalize declaration whitespace, and reject both tag syntaxes. Focused
   modern-hash and multiline mutations now fail for the stale-tag contract.
+- Second review finding — the required negative trunk sentence could coexist
+  with a contradictory availability claim or bare trunk-only Podfile entry.
+- Second review fix — reject `NetworkState` pod declarations without an
+  explicit Git source and scan outside the exact disclaimer for install,
+  availability, or publication claims. Contradictory-text and bare-install
+  mutations now fail for their intended trunk contracts.
 - Local Xcode remained unavailable and skipped truthfully. Merge remains
   conditional on clean exact-head review and successful final hosted reruns.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -53,8 +53,8 @@ implementation.
 - First hosted pull-request run — macOS baseline, framework build, XCTest,
   CodeQL Actions, and CodeQL Python passed. A duplicate push-triggered baseline
   for the same head was canceled after the pull-request run became authoritative.
-- Local Xcode remained unavailable and skipped truthfully. Final exact-head
-  review and hosted reruns remain required after this evidence update.
+- Local Xcode remained unavailable and skipped truthfully. Merge remains
+  conditional on clean exact-head review and successful final hosted reruns.
 
 ### Bugs / findings
 
@@ -68,8 +68,8 @@ implementation.
 
 ### Next action
 
-- Re-run exact-head review and require final hosted baseline and CodeQL success
-  before merge.
+- Merge only after clean exact-head review and final hosted baseline and CodeQL
+  success.
 
 ## 2026-06-21
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,71 @@
 # Changes
 
+## 2026-06-25 12:12 PDT - P2 - Clarify current CocoaPods source
+
+### Summary
+
+Documented that the checked-in root podspec describes current default-branch
+source while the historical `0.0.2` tag still resolves the original 2016 Swift
+implementation.
+
+### Work completed
+
+- Added a current-branch Git Podfile example without claiming CocoaPods trunk
+  publication.
+- Added reviewed-commit pinning guidance for reproducible builds.
+- Added exact positive and stale-tag regression contracts plus maintenance and
+  roadmap boundaries.
+
+### Threads
+
+- Started: none; the package-source documentation gap was completed directly.
+- Continued: none.
+- Stopped: none.
+
+### Files changed
+
+- `README.md` — added current source, stale-tag, trunk, and pinning guidance.
+- `scripts/check-baseline.py` — enforced the exact package-source boundary.
+- `AGENTS.md` — recorded the historical-tag maintenance rule.
+- `VISION.md` — recorded the package release boundary.
+- `docs/plans/2026-06-25-cocoapods-source-boundary.md` — recorded evidence,
+  scope, and verification.
+
+### Validation
+
+- Initial baseline check — failed on the missing plan.
+- Second red baseline check — after adding scope evidence, reported five missing
+  README fragments plus incomplete verification evidence.
+- First green attempt — exposed an overbroad stale-tag check that also rejected
+  explanatory prose; narrowed it to actual `pod 'NetworkState'` tag syntax.
+- Three hostile mutations — stale tag, CocoaPods trunk overclaim, and weakened
+  reviewed-commit guidance were rejected for the intended contract failures.
+- The first pinning mutation command allowed shell backtick substitution and
+  failed for the wrong reason; the safely quoted rerun passed the intended
+  rejection assertion.
+- All six Make aliases passed from the repository root and an external working
+  directory; each run included the baseline and all 12 Python policy tests.
+- Python bytecode compilation and `git diff --check` passed. Validation-created
+  bytecode plus the empty file produced by the misquoted mutation command were
+  removed before review.
+- Local Xcode remained unavailable and skipped truthfully. Hosted Xcode tests
+  and exact-head review remain pending.
+
+### Bugs / findings
+
+- P2: consumers could reasonably treat root podspec version `0.0.2` as evidence
+  that the same-named immutable tag contained the current implementation.
+
+### Blockers
+
+- Local Linux cannot run Xcode or CocoaPods lint; hosted macOS remains
+  authoritative for the existing framework build and XCTest truth table.
+
+### Next action
+
+- Open the pull request, run exact-head review, and require hosted baseline and
+  Xcode success before merge.
+
 ## 2026-06-21
 
 - Preserved the complete checkout root for absolute Makefile paths containing

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -64,6 +64,11 @@ implementation.
   explicit Git source and scan outside the exact disclaimer for install,
   availability, or publication claims. Contradictory-text and bare-install
   mutations now fail for their intended trunk contracts.
+- Third review finding — the phrase-specific trunk scan still missed common
+  `available in` and `install via` wording.
+- Third review fix — remove the one exact negative disclaimer and reject every
+  remaining `CocoaPods trunk` mention, avoiding language-specific false
+  negatives. Both newly identified wording variants now fail.
 - Local Xcode remained unavailable and skipped truthfully. Merge remains
   conditional on clean exact-head review and successful final hosted reruns.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -53,6 +53,11 @@ implementation.
 - First hosted pull-request run — macOS baseline, framework build, XCTest,
   CodeQL Actions, and CodeQL Python passed. A duplicate push-triggered baseline
   for the same head was canceled after the pull-request run became authoritative.
+- Final-review finding — Codex identified that the stale-tag regex missed
+  multiline `:tag =>` declarations and modern `tag:` Ruby hash syntax.
+- Review fix — parse Ruby code blocks into `NetworkState` pod declarations,
+  normalize declaration whitespace, and reject both tag syntaxes. Focused
+  modern-hash and multiline mutations now fail for the stale-tag contract.
 - Local Xcode remained unavailable and skipped truthfully. Merge remains
   conditional on clean exact-head review and successful final hosted reruns.
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,21 @@ make check
 
 The setup commands above are derived from repository files. Legacy mobile, Python, or JavaScript samples may require older SDKs or package versions than a modern workstation uses by default.
 
+### CocoaPods Source Boundary
+
+To inspect or integrate the current default-branch source through CocoaPods,
+use the repository as an external Git dependency:
+
+```ruby
+pod 'NetworkState', :git => 'https://github.com/garethpaul/NetworkState.git', :branch => 'master'
+```
+
+The checked-in root podspec describes the current source, but its `0.0.2` version matches a historical tag that predates the current Swift implementation and tests. Do not pin the dependency to version tag `0.0.2`; that tag resolves the 2016 source rather than the current default-branch implementation.
+
+A branch dependency is mutable. For reproducible builds, inspect the selected
+revision and replace `:branch => 'master'` with a reviewed commit. This
+repository does not claim that `NetworkState` is available from the CocoaPods trunk; a future package release needs a new immutable version, matching source revision, and successful podspec lint.
+
 ## Running or Using the Project
 
 - Import the framework and call `NetworkState.isConnectedToNetwork()` to receive a local boolean connectivity signal.

--- a/VISION.md
+++ b/VISION.md
@@ -49,6 +49,8 @@ Priority:
   of internet or service availability
 - Keep CocoaPods as the only declared package-manager integration until another
   manager is added and verified in a focused change
+- Keep the historical 0.0.2 tag distinct from the current root podspec and
+  default-branch source until a new immutable package release is prepared
 - Keep connectivity evaluation local to the device with no remote probes,
   telemetry, or endpoint checks
 

--- a/docs/plans/2026-06-25-cocoapods-source-boundary.md
+++ b/docs/plans/2026-06-25-cocoapods-source-boundary.md
@@ -69,4 +69,7 @@ published CocoaPods trunk release.
   contradictory trunk claim. The checker now rejects bare `NetworkState` pod
   declarations without Git plus separate install, availability, or publication
   claims outside the exact disclaimer; two focused mutations cover both paths.
+- A third review showed phrase-specific trunk matching still missed `available
+  in` and `install via`. The final rule removes the one exact disclaimer and
+  rejects any remaining `CocoaPods trunk` mention; both variants are covered.
 - Complete local, hosted, and review evidence is recorded in `CHANGES.md`.

--- a/docs/plans/2026-06-25-cocoapods-source-boundary.md
+++ b/docs/plans/2026-06-25-cocoapods-source-boundary.md
@@ -1,0 +1,64 @@
+---
+title: Document CocoaPods source boundary
+status: completed
+date: 2026-06-25
+---
+
+# Document CocoaPods Source Boundary
+
+## Goal
+
+Prevent consumers from treating the historical `0.0.2` tag as the current
+Swift implementation or assuming that the checked-in root podspec proves a
+published CocoaPods trunk release.
+
+## Evidence
+
+- The root `NetworkState.podspec` still declares version `0.0.2` and a source
+  tag derived from that version.
+- The historical 0.0.2 tag points to commit
+  `a310b6718f495f9d5ce835692533b6c8f073bdf9` from 2016.
+- The current default branch includes public API, guarded reachability
+  creation, a shared flag evaluator, exhaustive truth-table tests, and current
+  hosted validation that are absent from that tag.
+- No matching `NetworkState` spec was found in the CocoaPods Specs repository,
+  so trunk availability must not be claimed.
+
+## Decisions
+
+- Document a Git Podfile example that resolves the current root podspec from
+  `master` instead of recommending the stale historical tag.
+- State that branch installs are mutable and production consumers should
+  replace the branch with a reviewed commit.
+- Keep release versioning and tag creation out of this documentation-only
+  change; a future release requires a new immutable version and pod lint.
+- Add exact positive and stale-tag contracts to the dependency-free checker.
+
+## Verification
+
+- Run the baseline checker before the README change and capture the expected
+  missing-fragment failures.
+- Run focused hostile mutations for the stale tag, trunk overclaim, and
+  reviewed-commit guidance.
+- Run all Make aliases, direct checker/tests, external-directory verification,
+  Python compilation, and `git diff --check`.
+- Require hosted Xcode tests and exact-head review before merge.
+
+## Risks
+
+- `master` is not immutable; the README must make reviewed commit pinning
+  explicit.
+- The root podspec and historical tag continue to share a version number. This
+  change prevents unsafe guidance but does not create a package release.
+
+## Verification Result
+
+- The initial checker failed on the absent plan. After adding scope evidence,
+  it reported all five missing README fragments and incomplete plan evidence.
+- Three hostile mutations were rejected for recommending the historical 0.0.2
+  tag, claiming CocoaPods trunk availability, and weakening the reviewed commit
+  pinning guidance.
+- The first pinning mutation command accidentally allowed shell backtick
+  substitution and failed for the wrong reason; the safely quoted rerun was
+  rejected for the intended missing guidance.
+- Complete local, hosted, and review evidence is recorded in `CHANGES.md`.

--- a/docs/plans/2026-06-25-cocoapods-source-boundary.md
+++ b/docs/plans/2026-06-25-cocoapods-source-boundary.md
@@ -61,4 +61,8 @@ published CocoaPods trunk release.
 - The first pinning mutation command accidentally allowed shell backtick
   substitution and failed for the wrong reason; the safely quoted rerun was
   rejected for the intended missing guidance.
+- Exact-head Codex review found that the first stale-tag regex only caught a
+  single-line hash-rocket declaration. The corrected checker normalizes each
+  `NetworkState` declaration and rejects both multiline `:tag => '0.0.2'` and
+  modern `tag: '0.0.2'` syntax; focused hostile mutations cover both forms.
 - Complete local, hosted, and review evidence is recorded in `CHANGES.md`.

--- a/docs/plans/2026-06-25-cocoapods-source-boundary.md
+++ b/docs/plans/2026-06-25-cocoapods-source-boundary.md
@@ -65,4 +65,8 @@ published CocoaPods trunk release.
   single-line hash-rocket declaration. The corrected checker normalizes each
   `NetworkState` declaration and rejects both multiline `:tag => '0.0.2'` and
   modern `tag: '0.0.2'` syntax; focused hostile mutations cover both forms.
+- A follow-up review found that the required disclaimer could coexist with a
+  contradictory trunk claim. The checker now rejects bare `NetworkState` pod
+  declarations without Git plus separate install, availability, or publication
+  claims outside the exact disclaimer; two focused mutations cover both paths.
 - Complete local, hosted, and review evidence is recorded in `CHANGES.md`.

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -306,11 +306,7 @@ def main() -> int:
         "does not claim that `NetworkState` is available from the CocoaPods trunk"
     )
     trunk_claim_source = readme_source.replace(trunk_disclaimer, "")
-    if re.search(
-        r"(?:\binstall\s+from|\bavailable\s+(?:from|on)|\bpublished\s+(?:to|on))\s+(?:the\s+)?CocoaPods\s+trunk\b",
-        trunk_claim_source,
-        re.IGNORECASE,
-    ):
+    if re.search(r"\bCocoaPods\s+trunk\b", trunk_claim_source, re.IGNORECASE):
         failures.append("README must not claim CocoaPods trunk availability")
     if not all(
         evidence in cocoapods_source_plan.lower()

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -97,6 +97,7 @@ REQUIRED = [
     "docs/plans/2026-06-15-reachability-decision-truth-table.md",
     "docs/plans/2026-06-15-wwan-reachability-flag-matrix.md",
     "docs/plans/2026-06-21-spaced-makefile-path.md",
+    "docs/plans/2026-06-25-cocoapods-source-boundary.md",
     "docs/readme-overview.svg",
     "tests/test_makefile_root.py",
 ]
@@ -271,6 +272,35 @@ def main() -> int:
             failures.append(f".gitignore must include {expected}")
 
     readme_source = read("README.md")
+    cocoapods_source_plan = read(
+        "docs/plans/2026-06-25-cocoapods-source-boundary.md"
+    )
+    for fragment in [
+        "### CocoaPods Source Boundary",
+        "pod 'NetworkState', :git => 'https://github.com/garethpaul/NetworkState.git', :branch => 'master'",
+        "The checked-in root podspec describes the current source, but its `0.0.2` version matches a historical tag that predates the current Swift implementation and tests.",
+        "replace `:branch => 'master'` with a reviewed commit",
+        "does not claim that `NetworkState` is available from the CocoaPods trunk",
+    ]:
+        if fragment not in readme_source:
+            failures.append(f"README CocoaPods source boundary must include {fragment}")
+    if re.search(
+        r"pod\s+['\"]NetworkState['\"].*:tag\s*=>\s*['\"]0\.0\.2['\"]",
+        readme_source,
+    ):
+        failures.append("README must not recommend the stale 0.0.2 source tag")
+    if not all(
+        evidence in cocoapods_source_plan.lower()
+        for evidence in [
+            "status: completed",
+            "historical 0.0.2 tag",
+            "reviewed commit",
+            "hostile mutations",
+        ]
+    ):
+        failures.append(
+            "CocoaPods source-boundary plan must record completed tag, pinning, and mutation evidence"
+        )
     docs = readme_source + "\n" + read("VISION.md") + "\n" + read("SECURITY.md")
     location_independent_make_plan = read(
         "docs/plans/2026-06-13-location-independent-make.md"

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -284,11 +284,20 @@ def main() -> int:
     ]:
         if fragment not in readme_source:
             failures.append(f"README CocoaPods source boundary must include {fragment}")
-    if re.search(
-        r"pod\s+['\"]NetworkState['\"].*:tag\s*=>\s*['\"]0\.0\.2['\"]",
-        readme_source,
-    ):
-        failures.append("README must not recommend the stale 0.0.2 source tag")
+    ruby_blocks = re.findall(r"```ruby\s+(.*?)```", readme_source, re.DOTALL)
+    for ruby_block in ruby_blocks:
+        declarations = re.findall(
+            r"^\s*pod\s*(?:\(\s*)?['\"]NetworkState['\"].*?(?=^\s*pod\b|\Z)",
+            ruby_block,
+            re.DOTALL | re.MULTILINE,
+        )
+        for declaration in declarations:
+            normalized_declaration = re.sub(r"\s+", " ", declaration)
+            if re.search(
+                r"(?::tag\s*=>|tag:)\s*['\"]0\.0\.2['\"]",
+                normalized_declaration,
+            ):
+                failures.append("README must not recommend the stale 0.0.2 source tag")
     if not all(
         evidence in cocoapods_source_plan.lower()
         for evidence in [

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -293,11 +293,25 @@ def main() -> int:
         )
         for declaration in declarations:
             normalized_declaration = re.sub(r"\s+", " ", declaration)
+            if not re.search(r"(?::git\s*=>|git:)", normalized_declaration):
+                failures.append(
+                    "README must not recommend trunk-only NetworkState installation"
+                )
             if re.search(
                 r"(?::tag\s*=>|tag:)\s*['\"]0\.0\.2['\"]",
                 normalized_declaration,
             ):
                 failures.append("README must not recommend the stale 0.0.2 source tag")
+    trunk_disclaimer = (
+        "does not claim that `NetworkState` is available from the CocoaPods trunk"
+    )
+    trunk_claim_source = readme_source.replace(trunk_disclaimer, "")
+    if re.search(
+        r"(?:\binstall\s+from|\bavailable\s+(?:from|on)|\bpublished\s+(?:to|on))\s+(?:the\s+)?CocoaPods\s+trunk\b",
+        trunk_claim_source,
+        re.IGNORECASE,
+    ):
+        failures.append("README must not claim CocoaPods trunk availability")
     if not all(
         evidence in cocoapods_source_plan.lower()
         for evidence in [


### PR DESCRIPTION
## Summary
- document the current default-branch CocoaPods Git dependency
- distinguish the stale historical `0.0.2` tag from current Swift source
- require reviewed commit pinning and avoid CocoaPods trunk overclaims
- add exact static contracts and completed verification evidence

## Local verification
- red-first missing-plan and five-fragment failures
- hostile stale-tag, trunk-overclaim, and weakened-pinning mutations rejected
- all six Make aliases from root and an external directory
- 12 Python policy tests per alias run
- Python compilation and `git diff --check`

## Platform boundary
- local Linux truthfully skipped Xcode
- hosted macOS remains authoritative for framework build and XCTest
