### PR TITLE
Ignore local repository intelligence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@ xcuserdata
 .env
 .env.*
 
+# Local repository intelligence
+.explore/
+
 ## Other
 *.xccheckout
 *.moved-aside

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,4 +33,6 @@ This repository maintains a small Swift wrapper around legacy
 - Do not recommend the historical `0.0.2` tag as current source; package
   guidance must distinguish mutable branch installs from reviewed commit pins.
 - Keep checkout credentials disabled and the single hosted workflow intact.
+- Keep repository-local `.explore/` intelligence ignored; move durable
+  decisions into tracked plans, changes, or policies.
 - Record skipped device, carrier, captive-portal, and live-service validation.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,69 @@
 # Changes
 
+## 2026-06-25 14:54 PDT - P2 - Ignore local repository intelligence
+
+### Summary
+
+Kept maintainer-local `.explore/` notes out of source-control status and
+accidental pull-request changes while requiring durable decisions to remain in
+tracked repository documents.
+
+### Work completed
+
+- Added the active `.explore/` directory pattern to `.gitignore`.
+- Extended the canonical ignore contract and made it reject commented-out
+  patterns rather than accepting raw substrings.
+- Documented the local-only intelligence boundary in contributor, setup,
+  roadmap, and implementation-plan guidance.
+
+### Threads
+
+- Started: local repository intelligence ignore boundary.
+- Continued: canonical baseline ownership of local and generated artifacts.
+- Stopped: none.
+
+### Files changed
+
+- `.gitignore` — ignored repository-local `.explore/` files.
+- `scripts/check-baseline.py` — enforced active, non-comment ignore entries.
+- `tests/test_baseline_contracts.py` — covered commented ignore patterns.
+- `README.md` — distinguished local notes from source and durable evidence.
+- `AGENTS.md` — added the maintenance rule.
+- `VISION.md` — added the contribution guardrail.
+- `docs/plans/2026-06-25-local-intelligence-ignore.md` — recorded evidence,
+  decisions, verification, and risk.
+- `CHANGES.md` — recorded this P2 cycle.
+
+### Validation
+
+- Red-first baseline — failed with `.gitignore must include .explore/` before
+  the active ignore rule was added.
+- Red-first unit regression — failed because the active-pattern parser helper
+  did not yet exist.
+- Commented-rule hostile mutation — failed with the intended missing-pattern
+  error after the active rule was temporarily commented out.
+- All six Make aliases passed from the repository root and an external working
+  directory; each run included the baseline and 13 Python policy tests.
+- Direct Python discovery, syntax parsing, `git check-ignore`, and
+  `git diff --check` passed.
+- Hosted and exact-head review validation is pending.
+
+### Bugs / findings
+
+- P2: persistent local intelligence appeared as untracked source in every
+  checkout and could be staged or published accidentally.
+- P2: the prior raw-substring ignore checker would accept a commented-out rule.
+
+### Blockers
+
+- Local Linux cannot run Xcode; hosted macOS remains authoritative for the
+  framework build and XCTest truth table.
+
+### Next action
+
+- Complete hostile ignore mutation, local gates, exact-head review, and hosted
+  checks; merge only when all evidence is clean.
+
 ## 2026-06-25 12:12 PDT - P2 - Clarify current CocoaPods source
 
 ### Summary

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,7 +13,7 @@ tracked repository documents.
 - Added the active `.explore/` directory pattern to `.gitignore`.
 - Extended the canonical ignore contract and made it reject commented-out
   patterns or leading-whitespace lookalikes rather than accepting normalized
-  raw substrings.
+  raw substrings, then added an effective Git check for ordered negations.
 - Documented the local-only intelligence boundary in contributor, setup,
   roadmap, and implementation-plan guidance.
 
@@ -27,7 +27,8 @@ tracked repository documents.
 
 - `.gitignore` — ignored repository-local `.explore/` files.
 - `scripts/check-baseline.py` — enforced active, non-comment ignore entries.
-- `tests/test_baseline_contracts.py` — covered comments and leading whitespace.
+- `tests/test_baseline_contracts.py` — covered comments, leading whitespace,
+  and later negation behavior.
 - `README.md` — distinguished local notes from source and durable evidence.
 - `AGENTS.md` — added the maintenance rule.
 - `VISION.md` — added the contribution guardrail.
@@ -59,6 +60,10 @@ tracked repository documents.
   framework build and XCTest suite, confirming runner-image variance.
 - The authoritative pull-request job was rerun unchanged and passed the full
   baseline, 13 Python tests, framework build, and XCTest suite in 2m23s.
+- Third exact-head Codex review — found that a later `!.explore/` rule could
+  disable Git's ignore behavior while leaving the textual contract satisfied.
+- Review fix — require pinned `git check-ignore --no-index` success for a
+  representative local-intelligence path and cover positive/negated behavior.
 
 ### Bugs / findings
 
@@ -67,6 +72,8 @@ tracked repository documents.
 - P2: the prior raw-substring ignore checker would accept a commented-out rule.
 - P2: the first active-pattern parser normalized leading whitespace and could
   accept a rule that Git would not apply.
+- P2: the textual contract did not account for ordered negation rules that can
+  disable an earlier `.explore/` pattern.
 
 ### Blockers
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -62,8 +62,9 @@ tracked repository documents.
   baseline, 13 Python tests, framework build, and XCTest suite in 2m23s.
 - Third exact-head Codex review — found that a later `!.explore/` rule could
   disable Git's ignore behavior while leaving the textual contract satisfied.
-- Review fix — require pinned `git check-ignore --no-index` success for a
-  representative local-intelligence path and cover positive/negated behavior.
+- Review fix — require pinned `git check-ignore --no-index` success for both
+  the directory and a representative file, covering positive, negated, and
+  selective child re-inclusion behavior.
 
 ### Bugs / findings
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -51,7 +51,14 @@ tracked repository documents.
   accept ` .explore/` even though Git would not apply it to `.explore/foo`.
 - Review fix — preserve pattern bytes, ignore only actual comment lines, and
   cover the malformed leading-space rule in the permanent unit regression.
-- Hosted and exact-head review validation is pending.
+- Second exact-head Codex review — clean on
+  `fddb68246ed08e5f342aeca2bba8cedc40a08941` with no actionable findings.
+- CodeQL Actions and Python passed on the corrected exact head.
+- The first pull-request macOS runner exposed no installed iOS simulator and
+  failed before compilation; the duplicate exact-head push job passed the full
+  framework build and XCTest suite, confirming runner-image variance.
+- The authoritative pull-request job was rerun unchanged and passed the full
+  baseline, 13 Python tests, framework build, and XCTest suite in 2m23s.
 
 ### Bugs / findings
 
@@ -68,8 +75,8 @@ tracked repository documents.
 
 ### Next action
 
-- Complete hostile ignore mutation, local gates, exact-head review, and hosted
-  checks; merge only when all evidence is clean.
+- Rerun exact-head review and hosted checks for this evidence-only update, then
+  merge if they remain clean.
 
 ## 2026-06-25 12:12 PDT - P2 - Clarify current CocoaPods source
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,8 @@ tracked repository documents.
 
 - Added the active `.explore/` directory pattern to `.gitignore`.
 - Extended the canonical ignore contract and made it reject commented-out
-  patterns rather than accepting raw substrings.
+  patterns or leading-whitespace lookalikes rather than accepting normalized
+  raw substrings.
 - Documented the local-only intelligence boundary in contributor, setup,
   roadmap, and implementation-plan guidance.
 
@@ -26,7 +27,7 @@ tracked repository documents.
 
 - `.gitignore` — ignored repository-local `.explore/` files.
 - `scripts/check-baseline.py` — enforced active, non-comment ignore entries.
-- `tests/test_baseline_contracts.py` — covered commented ignore patterns.
+- `tests/test_baseline_contracts.py` — covered comments and leading whitespace.
 - `README.md` — distinguished local notes from source and durable evidence.
 - `AGENTS.md` — added the maintenance rule.
 - `VISION.md` — added the contribution guardrail.
@@ -46,6 +47,10 @@ tracked repository documents.
   directory; each run included the baseline and 13 Python policy tests.
 - Direct Python discovery, syntax parsing, `git check-ignore`, and
   `git diff --check` passed.
+- First exact-head Codex review — found that trimming leading whitespace could
+  accept ` .explore/` even though Git would not apply it to `.explore/foo`.
+- Review fix — preserve pattern bytes, ignore only actual comment lines, and
+  cover the malformed leading-space rule in the permanent unit regression.
 - Hosted and exact-head review validation is pending.
 
 ### Bugs / findings
@@ -53,6 +58,8 @@ tracked repository documents.
 - P2: persistent local intelligence appeared as untracked source in every
   checkout and could be staged or published accidentally.
 - P2: the prior raw-substring ignore checker would accept a commented-out rule.
+- P2: the first active-pattern parser normalized leading whitespace and could
+  accept a rule that Git would not apply.
 
 ### Blockers
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,8 @@ tracked repository documents.
 - Extended the canonical ignore contract and made it reject commented-out
   patterns or leading-whitespace lookalikes rather than accepting normalized
   raw substrings, then added an effective Git check for ordered negations.
+- Rejected force-added or historical tracked `.explore` files through a pinned
+  `git ls-files` query.
 - Documented the local-only intelligence boundary in contributor, setup,
   roadmap, and implementation-plan guidance.
 
@@ -28,7 +30,7 @@ tracked repository documents.
 - `.gitignore` — ignored repository-local `.explore/` files.
 - `scripts/check-baseline.py` — enforced active, non-comment ignore entries.
 - `tests/test_baseline_contracts.py` — covered comments, leading whitespace,
-  and later negation behavior.
+  later negation behavior, and force-added tracked files.
 - `README.md` — distinguished local notes from source and durable evidence.
 - `AGENTS.md` — added the maintenance rule.
 - `VISION.md` — added the contribution guardrail.
@@ -65,6 +67,10 @@ tracked repository documents.
 - Review fix — require pinned `git check-ignore --no-index` success for both
   the directory and a representative file, covering positive, negated, and
   selective child re-inclusion behavior.
+- Fourth exact-head Codex review — found that `--no-index` intentionally masks
+  force-added or historical tracked `.explore` files.
+- Review fix — query the index with pinned `git ls-files`, fail closed on query
+  errors, and reject every tracked local-intelligence path.
 
 ### Bugs / findings
 
@@ -75,6 +81,8 @@ tracked repository documents.
   accept a rule that Git would not apply.
 - P2: the textual contract did not account for ordered negation rules that can
   disable an earlier `.explore/` pattern.
+- P2: effective ignore checks alone did not reject already tracked `.explore`
+  files because `--no-index` intentionally ignores index state.
 
 ### Blockers
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ make build
 make check
 ```
 
+Repository-local `.explore/` files contain maintainer working notes and are
+ignored intentionally. They are not product source, package input, or review
+evidence; durable decisions belong in tracked plans, changes, and policies.
+
 The setup commands above are derived from repository files. Legacy mobile, Python, or JavaScript samples may require older SDKs or package versions than a modern workstation uses by default.
 
 ### CocoaPods Source Boundary

--- a/VISION.md
+++ b/VISION.md
@@ -77,6 +77,8 @@ Contribution rules:
 - Preserve deployment target alignment when changing package metadata.
 - Preserve framework version alignment when changing release metadata.
 - Preserve the shared framework scheme when changing Xcode project metadata.
+- Preserve the `.explore/` local-intelligence ignore boundary and record
+  durable maintenance decisions in tracked repository documents.
 
 ## Security
 

--- a/docs/plans/2026-06-25-local-intelligence-ignore.md
+++ b/docs/plans/2026-06-25-local-intelligence-ignore.md
@@ -23,12 +23,16 @@ in reviewed repository documents.
   Git would not apply it.
 - Trimming leading whitespace would also turn a malformed nonmatching rule into
   the required canonical pattern inside the checker.
+- A later `!.explore/` negation can disable the directory rule even when the
+  canonical text remains present.
 
 ## Decisions
 
 - Add the exact active `.explore/` directory pattern to `.gitignore`.
 - Parse active ignore entries without trimming their pattern bytes so comments
   and malformed leading whitespace cannot satisfy required ignore contracts.
+- Verify the representative path with pinned `git check-ignore --no-index` so
+  ordered negations and Git's real pattern semantics remain authoritative.
 - Document that local notes are not product source or durable review evidence.
 - Keep the change repository-local; do not delete or publish existing local
   intelligence files.
@@ -42,6 +46,7 @@ in reviewed repository documents.
 - Temporarily comment out the rule and prove the strengthened checker rejects
   it, then restore the active rule.
 - Prove a leading-space rule remains distinct from the required canonical rule.
+- Prove a later negation disables the effective ignore check.
 - Run every Make alias from the root and an external working directory.
 - Require exact-head Codex review and hosted Xcode/CodeQL success before merge.
 
@@ -61,7 +66,8 @@ in reviewed repository documents.
 - All six Make aliases passed from root and an external directory with 13
   Python policy tests per invocation.
 - Codex found and prompted the leading-whitespace correction; the corrected
-  exact head received a clean follow-up review.
+  exact head received a clean follow-up review. A later review found the
+  negation bypass, which is now covered through effective Git behavior.
 - CodeQL Actions/Python and both exact-head macOS jobs passed. One initial PR
   runner lacked an installed simulator; an unchanged rerun passed the complete
   framework build and XCTest suite, confirming transient runner variance.

--- a/docs/plans/2026-06-25-local-intelligence-ignore.md
+++ b/docs/plans/2026-06-25-local-intelligence-ignore.md
@@ -21,12 +21,14 @@ in reviewed repository documents.
   configuration exclusions but did not enforce the intelligence boundary.
 - A raw substring check would accept a commented-out ignore rule even though
   Git would not apply it.
+- Trimming leading whitespace would also turn a malformed nonmatching rule into
+  the required canonical pattern inside the checker.
 
 ## Decisions
 
 - Add the exact active `.explore/` directory pattern to `.gitignore`.
-- Parse active ignore entries in the baseline checker so comments cannot satisfy
-  required ignore contracts.
+- Parse active ignore entries without trimming their pattern bytes so comments
+  and malformed leading whitespace cannot satisfy required ignore contracts.
 - Document that local notes are not product source or durable review evidence.
 - Keep the change repository-local; do not delete or publish existing local
   intelligence files.
@@ -39,6 +41,7 @@ in reviewed repository documents.
 - Verify `git check-ignore` accepts a representative `.explore/` file.
 - Temporarily comment out the rule and prove the strengthened checker rejects
   it, then restore the active rule.
+- Prove a leading-space rule remains distinct from the required canonical rule.
 - Run every Make alias from the root and an external working directory.
 - Require exact-head Codex review and hosted Xcode/CodeQL success before merge.
 

--- a/docs/plans/2026-06-25-local-intelligence-ignore.md
+++ b/docs/plans/2026-06-25-local-intelligence-ignore.md
@@ -1,0 +1,50 @@
+---
+title: Ignore local repository intelligence
+status: completed
+date: 2026-06-25
+---
+
+# Ignore Local Repository Intelligence
+
+## Goal
+
+Keep maintainer-local `.explore/` notes out of source-control status, package
+input, and accidental pull-request changes while preserving durable decisions
+in reviewed repository documents.
+
+## Evidence
+
+- The repository already persists local exploration notes under `.explore/`.
+- `.gitignore` did not match that directory, so a freshly synchronized checkout
+  reported every local intelligence file as untracked.
+- The canonical checker enforced generated, signing, credential, and local
+  configuration exclusions but did not enforce the intelligence boundary.
+- A raw substring check would accept a commented-out ignore rule even though
+  Git would not apply it.
+
+## Decisions
+
+- Add the exact active `.explore/` directory pattern to `.gitignore`.
+- Parse active ignore entries in the baseline checker so comments cannot satisfy
+  required ignore contracts.
+- Document that local notes are not product source or durable review evidence.
+- Keep the change repository-local; do not delete or publish existing local
+  intelligence files.
+
+## Verification
+
+- Add the checker expectation before the ignore rule and capture the intended
+  `.gitignore must include .explore/` failure.
+- Run the canonical baseline and all Python policy tests.
+- Verify `git check-ignore` accepts a representative `.explore/` file.
+- Temporarily comment out the rule and prove the strengthened checker rejects
+  it, then restore the active rule.
+- Run every Make alias from the root and an external working directory.
+- Require exact-head Codex review and hosted Xcode/CodeQL success before merge.
+
+## Risks
+
+- Ignored local notes are not shared through Git. Any durable technical decision
+  must therefore be copied into tracked plans, changes, policies, or source.
+- This change does not alter reachability behavior, public API, package version,
+  Xcode settings, or hosted tool authority.

--- a/docs/plans/2026-06-25-local-intelligence-ignore.md
+++ b/docs/plans/2026-06-25-local-intelligence-ignore.md
@@ -25,6 +25,8 @@ in reviewed repository documents.
   the required canonical pattern inside the checker.
 - A later `!.explore/` negation can disable the directory rule even when the
   canonical text remains present.
+- `git check-ignore --no-index` intentionally ignores index state, so a
+  force-added or historical tracked file needs a separate repository query.
 
 ## Decisions
 
@@ -34,6 +36,7 @@ in reviewed repository documents.
 - Verify both the directory and a representative file with pinned
   `git check-ignore --no-index` so ordered negations, selective child
   re-inclusion, and Git's real pattern semantics remain authoritative.
+- Reject every tracked `.explore` path reported by pinned `git ls-files`.
 - Document that local notes are not product source or durable review evidence.
 - Keep the change repository-local; do not delete or publish existing local
   intelligence files.
@@ -48,6 +51,7 @@ in reviewed repository documents.
   it, then restore the active rule.
 - Prove a leading-space rule remains distinct from the required canonical rule.
 - Prove a later negation disables the effective ignore check.
+- Prove a force-added local-intelligence file is detected as tracked.
 - Run every Make alias from the root and an external working directory.
 - Require exact-head Codex review and hosted Xcode/CodeQL success before merge.
 
@@ -68,7 +72,8 @@ in reviewed repository documents.
   Python policy tests per invocation.
 - Codex found and prompted the leading-whitespace correction; the corrected
   exact head received a clean follow-up review. A later review found the
-  negation bypass, which is now covered through effective Git behavior.
+  negation bypass, which is now covered through effective Git behavior. The
+  next review found the tracked-file boundary, now covered through index state.
 - CodeQL Actions/Python and both exact-head macOS jobs passed. One initial PR
   runner lacked an installed simulator; an unchanged rerun passed the complete
   framework build and XCTest suite, confirming transient runner variance.

--- a/docs/plans/2026-06-25-local-intelligence-ignore.md
+++ b/docs/plans/2026-06-25-local-intelligence-ignore.md
@@ -31,8 +31,9 @@ in reviewed repository documents.
 - Add the exact active `.explore/` directory pattern to `.gitignore`.
 - Parse active ignore entries without trimming their pattern bytes so comments
   and malformed leading whitespace cannot satisfy required ignore contracts.
-- Verify the representative path with pinned `git check-ignore --no-index` so
-  ordered negations and Git's real pattern semantics remain authoritative.
+- Verify both the directory and a representative file with pinned
+  `git check-ignore --no-index` so ordered negations, selective child
+  re-inclusion, and Git's real pattern semantics remain authoritative.
 - Document that local notes are not product source or durable review evidence.
 - Keep the change repository-local; do not delete or publish existing local
   intelligence files.

--- a/docs/plans/2026-06-25-local-intelligence-ignore.md
+++ b/docs/plans/2026-06-25-local-intelligence-ignore.md
@@ -51,3 +51,17 @@ in reviewed repository documents.
   must therefore be copied into tracked plans, changes, policies, or source.
 - This change does not alter reachability behavior, public API, package version,
   Xcode settings, or hosted tool authority.
+
+## Verification Result
+
+- The red-first baseline rejected the absent `.explore/` rule.
+- The red-first unit regression rejected the missing active-pattern helper.
+- Commented and leading-space lookalikes were rejected for the intended
+  canonical-pattern boundary.
+- All six Make aliases passed from root and an external directory with 13
+  Python policy tests per invocation.
+- Codex found and prompted the leading-whitespace correction; the corrected
+  exact head received a clean follow-up review.
+- CodeQL Actions/Python and both exact-head macOS jobs passed. One initial PR
+  runner lacked an installed simulator; an unchanged rerun passed the complete
+  framework build and XCTest suite, confirming transient runner variance.

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -111,9 +111,9 @@ def read(path: str) -> str:
 
 def active_gitignore_patterns(source: str) -> set[str]:
     return {
-        line.strip()
+        line
         for line in source.splitlines()
-        if line.strip() and not line.lstrip().startswith("#")
+        if line and not line.startswith("#")
     }
 
 

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -128,6 +128,20 @@ def git_ignores(root: Path, path: str) -> bool:
     return result.returncode == 0
 
 
+def git_tracked_paths(root: Path, pathspec: str) -> list[str]:
+    result = subprocess.run(
+        ["/usr/bin/git", "ls-files", "--", pathspec],
+        cwd=root,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return [f"<git ls-files failed with {result.returncode}>"]
+    return result.stdout.splitlines()
+
+
 def main() -> int:
     failures = []
     for path in REQUIRED:
@@ -295,6 +309,12 @@ def main() -> int:
     for ignored_path in [".explore/", ".explore/REPO_MAP.md"]:
         if not git_ignores(ROOT, ignored_path):
             failures.append(f".gitignore must effectively ignore {ignored_path}")
+    tracked_explore_paths = git_tracked_paths(ROOT, ".explore")
+    if tracked_explore_paths:
+        failures.append(
+            ".explore must not contain tracked files: "
+            + ", ".join(tracked_explore_paths)
+        )
 
     readme_source = read("README.md")
     cocoapods_source_plan = read(

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -292,8 +292,9 @@ def main() -> int:
     ]:
         if expected not in gitignore_patterns:
             failures.append(f".gitignore must include {expected}")
-    if not git_ignores(ROOT, ".explore/REPO_MAP.md"):
-        failures.append(".gitignore must effectively ignore .explore/ files")
+    for ignored_path in [".explore/", ".explore/REPO_MAP.md"]:
+        if not git_ignores(ROOT, ignored_path):
+            failures.append(f".gitignore must effectively ignore {ignored_path}")
 
     readme_source = read("README.md")
     cocoapods_source_plan = read(

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -98,13 +98,23 @@ REQUIRED = [
     "docs/plans/2026-06-15-wwan-reachability-flag-matrix.md",
     "docs/plans/2026-06-21-spaced-makefile-path.md",
     "docs/plans/2026-06-25-cocoapods-source-boundary.md",
+    "docs/plans/2026-06-25-local-intelligence-ignore.md",
     "docs/readme-overview.svg",
+    "tests/test_baseline_contracts.py",
     "tests/test_makefile_root.py",
 ]
 
 
 def read(path: str) -> str:
     return (ROOT / path).read_text(encoding="utf-8", errors="replace")
+
+
+def active_gitignore_patterns(source: str) -> set[str]:
+    return {
+        line.strip()
+        for line in source.splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    }
 
 
 def main() -> int:
@@ -256,7 +266,7 @@ def main() -> int:
     ):
         failures.append("shared framework scheme must build the NetworkState framework target")
 
-    gitignore = read(".gitignore")
+    gitignore_patterns = active_gitignore_patterns(read(".gitignore"))
     for expected in [
         "DerivedData/",
         "*.local.xcconfig",
@@ -267,8 +277,9 @@ def main() -> int:
         "*.p8",
         ".xcode.env.local",
         ".env",
+        ".explore/",
     ]:
-        if expected not in gitignore:
+        if expected not in gitignore_patterns:
             failures.append(f".gitignore must include {expected}")
 
     readme_source = read("README.md")

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -117,6 +117,17 @@ def active_gitignore_patterns(source: str) -> set[str]:
     }
 
 
+def git_ignores(root: Path, path: str) -> bool:
+    result = subprocess.run(
+        ["/usr/bin/git", "check-ignore", "--quiet", "--no-index", path],
+        cwd=root,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=False,
+    )
+    return result.returncode == 0
+
+
 def main() -> int:
     failures = []
     for path in REQUIRED:
@@ -281,6 +292,8 @@ def main() -> int:
     ]:
         if expected not in gitignore_patterns:
             failures.append(f".gitignore must include {expected}")
+    if not git_ignores(ROOT, ".explore/REPO_MAP.md"):
+        failures.append(".gitignore must effectively ignore .explore/ files")
 
     readme_source = read("README.md")
     cocoapods_source_plan = read(

--- a/tests/test_baseline_contracts.py
+++ b/tests/test_baseline_contracts.py
@@ -1,0 +1,25 @@
+import importlib.util
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location(
+    "networkstate_check_baseline", ROOT / "scripts/check-baseline.py"
+)
+CHECK_BASELINE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(CHECK_BASELINE)
+
+
+class GitignoreContractTests(unittest.TestCase):
+    def test_commented_patterns_are_not_active(self):
+        source = "# .explore/\n.explore-cache/\n\nDerivedData/\n"
+
+        self.assertEqual(
+            CHECK_BASELINE.active_gitignore_patterns(source),
+            {".explore-cache/", "DerivedData/"},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_baseline_contracts.py
+++ b/tests/test_baseline_contracts.py
@@ -30,11 +30,13 @@ class GitignoreContractTests(unittest.TestCase):
             (root / ".explore").mkdir()
             (root / ".explore/REPO_MAP.md").touch()
 
+            self.assertTrue(CHECK_BASELINE.git_ignores(root, ".explore/"))
             self.assertTrue(
                 CHECK_BASELINE.git_ignores(root, ".explore/REPO_MAP.md")
             )
             with (root / ".gitignore").open("a", encoding="utf-8") as gitignore:
                 gitignore.write("!.explore/\n")
+            self.assertFalse(CHECK_BASELINE.git_ignores(root, ".explore/"))
             self.assertFalse(
                 CHECK_BASELINE.git_ignores(root, ".explore/REPO_MAP.md")
             )

--- a/tests/test_baseline_contracts.py
+++ b/tests/test_baseline_contracts.py
@@ -41,6 +41,24 @@ class GitignoreContractTests(unittest.TestCase):
                 CHECK_BASELINE.git_ignores(root, ".explore/REPO_MAP.md")
             )
 
+    def test_force_added_explore_files_are_tracked(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            subprocess.run(["/usr/bin/git", "init", "-q"], cwd=root, check=True)
+            (root / ".gitignore").write_text(".explore/\n", encoding="utf-8")
+            (root / ".explore").mkdir()
+            (root / ".explore/REPO_MAP.md").touch()
+            subprocess.run(
+                ["/usr/bin/git", "add", "-f", ".explore/REPO_MAP.md"],
+                cwd=root,
+                check=True,
+            )
+
+            self.assertEqual(
+                CHECK_BASELINE.git_tracked_paths(root, ".explore"),
+                [".explore/REPO_MAP.md"],
+            )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_baseline_contracts.py
+++ b/tests/test_baseline_contracts.py
@@ -12,12 +12,12 @@ SPEC.loader.exec_module(CHECK_BASELINE)
 
 
 class GitignoreContractTests(unittest.TestCase):
-    def test_commented_patterns_are_not_active(self):
-        source = "# .explore/\n.explore-cache/\n\nDerivedData/\n"
+    def test_comments_and_leading_whitespace_do_not_create_required_patterns(self):
+        source = "# .explore/\n .explore/\n.explore-cache/\n\nDerivedData/\n"
 
         self.assertEqual(
             CHECK_BASELINE.active_gitignore_patterns(source),
-            {".explore-cache/", "DerivedData/"},
+            {" .explore/", ".explore-cache/", "DerivedData/"},
         )
 
 

--- a/tests/test_baseline_contracts.py
+++ b/tests/test_baseline_contracts.py
@@ -1,5 +1,7 @@
 import importlib.util
 from pathlib import Path
+import subprocess
+import tempfile
 import unittest
 
 
@@ -19,6 +21,23 @@ class GitignoreContractTests(unittest.TestCase):
             CHECK_BASELINE.active_gitignore_patterns(source),
             {" .explore/", ".explore-cache/", "DerivedData/"},
         )
+
+    def test_later_negation_disables_effective_ignore(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            subprocess.run(["/usr/bin/git", "init", "-q"], cwd=root, check=True)
+            (root / ".gitignore").write_text(".explore/\n", encoding="utf-8")
+            (root / ".explore").mkdir()
+            (root / ".explore/REPO_MAP.md").touch()
+
+            self.assertTrue(
+                CHECK_BASELINE.git_ignores(root, ".explore/REPO_MAP.md")
+            )
+            with (root / ".gitignore").open("a", encoding="utf-8") as gitignore:
+                gitignore.write("!.explore/\n")
+            self.assertFalse(
+                CHECK_BASELINE.git_ignores(root, ".explore/REPO_MAP.md")
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- ignore maintainer-local `.explore/` intelligence
- enforce active, non-comment ignore patterns in the canonical baseline
- add a permanent regression test and document the durable-evidence boundary

## Red / green evidence
- baseline failed with `.gitignore must include .explore/` before the rule
- unit regression failed before `active_gitignore_patterns` existed
- a commented-rule hostile mutation failed for the intended missing-pattern error
- all six Make aliases passed from root and an external directory
- 13 Python policy tests, syntax parsing, `git check-ignore`, and `git diff --check` passed

## Risk
No Swift API, reachability behavior, package metadata, Xcode settings, or hosted authority changes.
