### PR TITLE
Replace vacuous connectivity test with deterministic snapshots

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,8 @@ This repository maintains a small Swift wrapper around legacy
 - Guard WWAN-only constants to iOS-family builds.
 - Describe results as local route reachability, never proof of internet or
   service availability.
+- Preserve deterministic nil/supplied snapshot tests; do not replace them with
+  tautological assertions against the host's live connectivity.
 
 ## Maintenance
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,58 @@
 # Changes
 
+## 2026-06-26 04:35 PDT - P2 - Deterministic reachability snapshot coverage
+
+### Summary
+
+Replaced a tautological live-network Boolean assertion with deterministic
+coverage for unavailable and supplied SystemConfiguration flag snapshots.
+
+### Work completed
+
+- Added an internal closure-based snapshot seam while preserving the public
+  `isConnectedToNetwork()` Boolean API.
+- Routed reachability creation and flag-fetch failures through a nil snapshot
+  that fails closed.
+- Added XCTest for nil and supplied snapshots plus four portable mutation
+  contracts that reject missing guards, evaluator bypass, and tautological
+  tests.
+
+### Threads
+
+- Started: none; the focused testability gap was handled directly.
+- Continued: none.
+- Stopped: none.
+
+### Files changed
+
+- `NetworkState/NetworkState.swift` — extracted deterministic snapshot evaluation.
+- `NetworkStateTests/NetworkStateTests.swift` — replaced the vacuous live-route test.
+- `scripts/check-baseline.py`, `tests/test_baseline_contracts.py` — added contracts and mutations.
+- `README.md`, `SECURITY.md`, `VISION.md`, `AGENTS.md` — documented the boundary.
+- `docs/plans/2026-06-26-deterministic-snapshot-provider.md` — recorded the implementation plan.
+
+### Validation
+
+- RED baseline and focused test failed on the missing provider seam.
+- The repaired baseline, all four focused mutation contracts, all 19 Python
+  policy tests, root and external-directory `make check`, Python compilation,
+  and `git diff --check` pass. Local Xcode/XCTest skip because `xcodebuild` is
+  unavailable; hosted macOS and CodeQL remain merge gates.
+
+### Bugs / findings
+
+- The removed test asserted `result || !result`, which can never detect a
+  reachability regression or exercise the flag-fetch failure path.
+
+### Blockers
+
+- Live device, carrier, captive-portal, and service reachability remain outside
+  deterministic unit-test scope.
+
+### Next action
+
+- Run root, external, and hosted gates, then merge only the exact reviewed head.
+
 ## 2026-06-25 14:54 PDT - P2 - Ignore local repository intelligence
 
 ### Summary

--- a/NetworkState/NetworkState.swift
+++ b/NetworkState/NetworkState.swift
@@ -10,22 +10,31 @@ import SystemConfiguration
 
 public class NetworkState {
     public class func isConnectedToNetwork() -> Bool {
-        var zeroAddress = sockaddr_in()
-        zeroAddress.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
-        zeroAddress.sin_family = sa_family_t(AF_INET)
+        return isConnectedToNetwork(flagsProvider: {
+            var zeroAddress = sockaddr_in()
+            zeroAddress.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+            zeroAddress.sin_family = sa_family_t(AF_INET)
 
-        let defaultRouteReachability = withUnsafePointer(to: &zeroAddress) {
-            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
-                SCNetworkReachabilityCreateWithAddress(nil, $0)
+            let defaultRouteReachability = withUnsafePointer(to: &zeroAddress) {
+                $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                    SCNetworkReachabilityCreateWithAddress(nil, $0)
+                }
             }
-        }
 
-        guard let reachability = defaultRouteReachability else {
-            return false
-        }
+            guard let reachability = defaultRouteReachability else {
+                return nil
+            }
 
-        var flags = SCNetworkReachabilityFlags()
-        if !SCNetworkReachabilityGetFlags(reachability, &flags) {
+            var flags = SCNetworkReachabilityFlags()
+            guard SCNetworkReachabilityGetFlags(reachability, &flags) else {
+                return nil
+            }
+            return flags
+        })
+    }
+
+    class func isConnectedToNetwork(flagsProvider: () -> SCNetworkReachabilityFlags?) -> Bool {
+        guard let flags = flagsProvider() else {
             return false
         }
         return isReachableWithFlags(flags)

--- a/NetworkStateTests/NetworkStateTests.swift
+++ b/NetworkStateTests/NetworkStateTests.swift
@@ -8,13 +8,26 @@
 
 import XCTest
 import SystemConfiguration
-import NetworkState
+@testable import NetworkState
 
 class NetworkStateTests: XCTestCase {
 
-    func testConnectivityCheckReturnsBoolean() {
-        let result = NetworkState.isConnectedToNetwork()
-        XCTAssertTrue(result || !result)
+    func testMissingReachabilitySnapshotIsUnavailable() {
+        XCTAssertFalse(NetworkState.isConnectedToNetwork(flagsProvider: { nil }))
+    }
+
+    func testProvidedReachabilitySnapshotUsesSharedEvaluator() {
+        let reachable = SCNetworkReachabilityFlags.reachable
+        let unavailable = SCNetworkReachabilityFlags()
+
+        XCTAssertEqual(
+            NetworkState.isConnectedToNetwork(flagsProvider: { reachable }),
+            NetworkState.isReachableWithFlags(reachable)
+        )
+        XCTAssertEqual(
+            NetworkState.isConnectedToNetwork(flagsProvider: { unavailable }),
+            NetworkState.isReachableWithFlags(unavailable)
+        )
     }
 
     func testReachabilityFlagEvaluation() {

--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ repository does not claim that `NetworkState` is available from the CocoaPods tr
 
 - Import the framework and call `NetworkState.isConnectedToNetwork()` to receive a local boolean connectivity signal.
 - `NetworkState.isReachableWithFlags(_:)` keeps reachability flag evaluation testable for fixture-style checks.
+- Deterministic XCTest supplies optional flag snapshots through an internal
+  provider seam, proving unavailable snapshots fail closed and supplied flags
+  use the same public evaluator without depending on the host network.
 - Automatic connection reachability flags are considered reachable when no user intervention is required.
 - Automatic connection handling still requires the reachable flag, so connection-on-demand flags alone do not report connectivity.
 - Combined automatic connection flags remain reachable when the base reachable
@@ -161,7 +164,8 @@ DESTINATION='platform=iOS Simulator,name=iPhone 16 Pro' ./build.sh
   enforce those provider-side settings by itself.
 - `./build.sh` on macOS with Xcode
 - `pod spec lint NetworkState.podspec` when preparing CocoaPods release metadata
-- XCTest coverage includes reachable, connection-required, and unreachable reachability flag combinations.
+- XCTest coverage includes unavailable snapshots plus reachable,
+  connection-required, and unreachable reachability flag combinations.
 
 The Make targets run the same SDK-free static baseline on non-macOS hosts. Use
 `./build.sh` or Xcode for the full framework test run when the legacy toolchain

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -33,6 +33,8 @@ Helpful reports include:
   observer, or teardown lifecycle; callers must request a fresh snapshot when
   their own application lifecycle requires one.
 - Reachability flag evaluation should remain deterministic and covered without live network telemetry.
+- Missing SystemConfiguration flag snapshots must fail closed, with tests using
+  the internal provider seam rather than inferring behavior from the host route.
 - Automatic connection reachability flags should be evaluated locally and covered without live network telemetry.
 - Automatic connection handling should still require the reachable flag before reporting connectivity.
 - Combined automatic connection flags should stay covered so on-demand and

--- a/VISION.md
+++ b/VISION.md
@@ -20,6 +20,7 @@ Priority:
 - Keep podspec, Xcode project, and README usage aligned
 - Maintain test coverage for the helper behavior
 - Keep reachability flag evaluation covered by deterministic tests
+- Keep snapshot acquisition failure covered without a live network dependency
 - Keep automatic connection reachability flags covered without live network state
 - Keep automatic connection behavior constrained so it requires the reachable flag
 - Keep combined automatic connection flags covered in fixture tests

--- a/docs/plans/2026-06-26-deterministic-snapshot-provider.md
+++ b/docs/plans/2026-06-26-deterministic-snapshot-provider.md
@@ -1,0 +1,59 @@
+# Deterministic Reachability Snapshot Provider Implementation Plan
+
+Status: Completed
+
+> **For Claude:** REQUIRED SUB-SKILL: Use executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace the vacuous live-network Boolean test with deterministic coverage for unavailable and supplied reachability flag snapshots.
+
+**Architecture:** Keep `isConnectedToNetwork()` as the unchanged public entry point and leave SystemConfiguration acquisition there. Add one internal closure-based overload that accepts an optional flag snapshot and delegates non-nil values to the existing public flag evaluator, allowing XCTest to cover acquisition failure and success without live network state.
+
+**Tech Stack:** Swift, SystemConfiguration, XCTest, Python static contracts, Xcode hosted tests.
+
+---
+
+### Task 1: Add RED snapshot contracts
+
+**Files:**
+- Modify: `NetworkStateTests/NetworkStateTests.swift`
+- Modify: `scripts/check-baseline.py`
+- Modify: `tests/test_baseline_contracts.py`
+
+Add XCTest for a nil provider returning false and supplied flags matching `isReachableWithFlags`. Reject the old `result || !result` tautology. Add hostile source mutations that bypass nil handling or the shared evaluator.
+
+Run `python3 scripts/check-baseline.py`; expect failure because the internal provider overload does not exist.
+
+### Task 2: Extract the minimal seam
+
+**Files:**
+- Modify: `NetworkState/NetworkState.swift`
+
+Make the public method acquire an optional snapshot and pass it to an internal closure-based overload. Return false for nil and delegate non-nil flags to `isReachableWithFlags`.
+
+Run the focused Python tests and baseline; expect green.
+
+### Task 3: Reconcile maintenance documentation
+
+**Files:**
+- Modify: `README.md`
+- Modify: `SECURITY.md`
+- Modify: `VISION.md`
+- Modify: `AGENTS.md`
+- Modify: `CHANGES.md`
+- Modify: `docs/plans/2026-06-26-deterministic-snapshot-provider.md`
+
+Record the deterministic boundary, RED/GREEN evidence, lack of public API change, runtime limitations, and next live-network validation step.
+
+### Task 4: Verify and ship
+
+Run root and external-directory `make check`, Python tests, `git diff --check`, hosted Xcode, CodeQL, and exact-head Codex review. Merge only the exact green head.
+
+## Result
+
+The public API now supplies an optional SystemConfiguration flag snapshot to an
+internal evaluator. Nil snapshots fail closed and supplied snapshots delegate
+to `isReachableWithFlags(_:)`. The former tautological live-network XCTest was
+replaced with deterministic nil and supplied-snapshot coverage; final local and
+hosted evidence is recorded in `CHANGES.md` before merge. Root and
+external-directory `make check`, all 19 Python policy tests, Python compilation,
+and `git diff --check` pass locally; native XCTest remains a hosted gate.

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -99,6 +99,7 @@ REQUIRED = [
     "docs/plans/2026-06-21-spaced-makefile-path.md",
     "docs/plans/2026-06-25-cocoapods-source-boundary.md",
     "docs/plans/2026-06-25-local-intelligence-ignore.md",
+    "docs/plans/2026-06-26-deterministic-snapshot-provider.md",
     "docs/readme-overview.svg",
     "tests/test_baseline_contracts.py",
     "tests/test_makefile_root.py",
@@ -142,6 +143,34 @@ def git_tracked_paths(root: Path, pathspec: str) -> list[str]:
     return result.stdout.splitlines()
 
 
+def reachability_snapshot_contract_errors(swift: str, tests: str) -> list[str]:
+    errors = []
+    required_source = [
+        "class func isConnectedToNetwork(flagsProvider: () -> SCNetworkReachabilityFlags?) -> Bool",
+        "guard let flags = flagsProvider() else",
+        "return isReachableWithFlags(flags)",
+        "return isConnectedToNetwork(flagsProvider:",
+    ]
+    for contract in required_source:
+        if contract not in swift:
+            errors.append(f"deterministic reachability snapshot contract is missing: {contract}")
+
+    required_tests = [
+        "@testable import NetworkState",
+        "testMissingReachabilitySnapshotIsUnavailable",
+        "NetworkState.isConnectedToNetwork(flagsProvider: { nil })",
+        "testProvidedReachabilitySnapshotUsesSharedEvaluator",
+        "NetworkState.isReachableWithFlags(reachable)",
+        "NetworkState.isReachableWithFlags(unavailable)",
+    ]
+    for contract in required_tests:
+        if contract not in tests:
+            errors.append(f"deterministic reachability snapshot test is missing: {contract}")
+    if "result || !result" in tests:
+        errors.append("tests must not use a tautological Boolean connectivity assertion")
+    return errors
+
+
 def main() -> int:
     failures = []
     for path in REQUIRED:
@@ -149,6 +178,8 @@ def main() -> int:
             failures.append(f"required file missing: {path}")
 
     swift = read("NetworkState/NetworkState.swift")
+    tests = read("NetworkStateTests/NetworkStateTests.swift")
+    failures.extend(reachability_snapshot_contract_errors(swift, tests))
     if "public class func isConnectedToNetwork() -> Bool" not in swift:
         failures.append("isConnectedToNetwork must be public for framework consumers")
     if "guard let reachability = defaultRouteReachability" not in swift:
@@ -176,11 +207,8 @@ def main() -> int:
     if "flags.contains(.reachable)" not in swift:
         failures.append("reachability evaluation must derive connectivity from the Reachable flag")
 
-    tests = read("NetworkStateTests/NetworkStateTests.swift")
     if "import NetworkState" not in tests:
         failures.append("tests must import the framework module")
-    if "NetworkState.isConnectedToNetwork()" not in tests:
-        failures.append("tests must exercise the public connectivity API")
     if "testReachabilityFlagEvaluation" not in tests or "isReachableWithFlags" not in tests:
         failures.append("tests must cover reachability flag evaluation")
     if "testReachabilityFlagEvaluationAllowsAutomaticConnection" not in tests:
@@ -594,6 +622,18 @@ def main() -> int:
         or "hostile mutations rejected" not in assumptions_plan
     ):
         failures.append("platform assumptions plan must record completed verification")
+    snapshot_plan = read("docs/plans/2026-06-26-deterministic-snapshot-provider.md")
+    if "Status: Completed" not in snapshot_plan or "make check" not in snapshot_plan:
+        failures.append("deterministic snapshot provider plan must record completed verification")
+    documentation_contracts = {
+        "README.md": "unavailable snapshots fail closed",
+        "SECURITY.md": "Missing SystemConfiguration flag snapshots must fail closed",
+        "VISION.md": "snapshot acquisition failure",
+        "CHANGES.md": "Deterministic reachability snapshot coverage",
+    }
+    for relative_path, phrase in documentation_contracts.items():
+        if phrase not in read(relative_path):
+            failures.append(f"{relative_path} must document deterministic snapshot coverage")
     workflow_files = sorted(
         path.relative_to(ROOT).as_posix()
         for path in (ROOT / ".github/workflows").iterdir()

--- a/tests/test_baseline_contracts.py
+++ b/tests/test_baseline_contracts.py
@@ -60,5 +60,32 @@ class GitignoreContractTests(unittest.TestCase):
             )
 
 
+class ReachabilitySnapshotContractTests(unittest.TestCase):
+    def setUp(self):
+        self.swift = (ROOT / "NetworkState/NetworkState.swift").read_text(encoding="utf-8")
+        self.tests = (ROOT / "NetworkStateTests/NetworkStateTests.swift").read_text(encoding="utf-8")
+
+    def test_current_snapshot_contract_is_complete(self):
+        self.assertEqual(
+            [],
+            CHECK_BASELINE.reachability_snapshot_contract_errors(self.swift, self.tests),
+        )
+
+    def test_nil_snapshot_guard_is_required(self):
+        mutated = self.swift.replace("guard let flags = flagsProvider() else", "if let flags = flagsProvider()")
+        self.assertTrue(CHECK_BASELINE.reachability_snapshot_contract_errors(mutated, self.tests))
+
+    def test_shared_flag_evaluator_is_required(self):
+        mutated = self.swift.replace("return isReachableWithFlags(flags)", "return true", 1)
+        self.assertTrue(CHECK_BASELINE.reachability_snapshot_contract_errors(mutated, self.tests))
+
+    def test_tautological_live_network_assertion_is_rejected(self):
+        mutated_tests = self.tests + "\n// result || !result\n"
+        self.assertIn(
+            "tests must not use a tautological Boolean connectivity assertion",
+            CHECK_BASELINE.reachability_snapshot_contract_errors(self.swift, mutated_tests),
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- Replace the tautological live-network Boolean assertion with deterministic nil and supplied-snapshot XCTest coverage.
- Add an internal closure-based seam while preserving the public connectivity API.
- Add four portable mutation contracts for nil handling, evaluator delegation, and tautology rejection.

## Baseline

The prior native test asserted a Boolean expression that was true for either connectivity result and depended on live reachability state. It therefore could not demonstrate the intended behavior or fail deterministically when snapshot handling regressed.

## Improvements

- Inject reachability snapshots through an internal closure without changing the public API.
- Test nil and supplied snapshots deterministically.
- Reject tautological assertions and bypasses with portable mutation contracts.

## Validation

- Root and external-directory `make check` passed.
- All 19 Python policy tests passed.
- The focused four-case snapshot mutation suite passed.
- Python compilation and `git diff --check` passed.

## Risk

Local Xcode and XCTest execution was unavailable because `xcodebuild` is not installed. Simulator, device, carrier, captive-portal, VPN, DNS, and live-service behavior were not exercised.

## Follow-Ups

Keep hosted macOS and CodeQL as merge gates, preserve deterministic snapshot injection, and add native cases when new reachability flag combinations are supported.
