### PR TITLE
Reconcile network test roadmap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,8 @@ This repository maintains a small Swift wrapper around legacy
   service availability.
 - Preserve deterministic nil/supplied snapshot tests; do not replace them with
   tautological assertions against the host's live connectivity.
+- Deterministic snapshots cover unavailable and reachable routes without live-network dependence.
+- Constrained-path state is not represented by SCNetworkReachabilityFlags; testing it requires a separately reviewed Network framework migration.
 
 ## Maintenance
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,65 @@
 # Changes
 
+## 2026-06-26 13:06 PDT - P2 - Reconcile network test roadmap
+
+### Summary
+
+Retired a stale roadmap item after the deterministic snapshot suite covered
+unavailable and reachable route states, while documenting that Low Data Mode
+and constrained-path state belong to a different Apple framework boundary.
+
+### Work completed
+
+- Deterministic snapshots cover unavailable and reachable routes without live-network dependence.
+- Constrained-path state is not represented by SCNetworkReachabilityFlags; testing it requires a separately reviewed Network framework migration.
+- Removed the combined offline/online/constrained roadmap item without changing
+  the public Boolean API, iOS 8 package boundary, or Swift implementation.
+- Added design and implementation records backed by Apple SystemConfiguration
+  and Network framework documentation.
+
+### Threads
+
+- Started: none; the documentation reconciliation was handled directly.
+- Continued: none.
+- Stopped: none.
+
+### Files changed
+
+- `AGENTS.md`, `README.md`, `SECURITY.md`, and `VISION.md` — document the
+  completed snapshot coverage and constrained-path compatibility boundary.
+- `scripts/check-baseline.py` — enforce exact guidance, roadmap retirement, and
+  completed-plan evidence.
+- `docs/plans/2026-06-26-network-test-roadmap-design.md` and
+  `docs/plans/2026-06-26-network-test-roadmap.md` — record the decision and plan.
+- `CHANGES.md` — record this maintenance cycle.
+
+### Validation
+
+- Red-first `make check` rejected the pending plan, missing guidance in all five
+  maintained documents, and stale roadmap item before documentation changes.
+- Four isolated hostile mutations for stale roadmap text, missing constrained
+  guidance, missing snapshot guidance, and incomplete-plan evidence were
+  rejected.
+- All six Make aliases passed from the repository root and an external
+  directory, each including the baseline and 19 Python policy tests.
+- Local Xcode remains unavailable, so hosted framework compilation and XCTest
+  remain required before merge.
+
+### Bugs / findings
+
+- P2 documentation correctness: the roadmap grouped already-covered unavailable
+  and reachable snapshots with constrained-path state that the maintained
+  `SCNetworkReachabilityFlags` API cannot represent.
+
+### Blockers
+
+- Testing Low Data Mode or other constrained paths requires a separately
+  reviewed Network framework and deployment-compatibility decision.
+
+### Next action
+
+- Complete all validation and merge only the exact unchanged green PR head.
+
 ## 2026-06-26 04:35 PDT - P2 - Deterministic reachability snapshot coverage
 
 ### Summary

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ repository does not claim that `NetworkState` is available from the CocoaPods tr
 - Deterministic XCTest supplies optional flag snapshots through an internal
   provider seam, proving unavailable snapshots fail closed and supplied flags
   use the same public evaluator without depending on the host network.
+- Deterministic snapshots cover unavailable and reachable routes without live-network dependence.
+- Constrained-path state is not represented by SCNetworkReachabilityFlags; testing it requires a separately reviewed Network framework migration.
 - Automatic connection reachability flags are considered reachable when no user intervention is required.
 - Automatic connection handling still requires the reachable flag, so connection-on-demand flags alone do not report connectivity.
 - Combined automatic connection flags remain reachable when the base reachable

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -35,6 +35,8 @@ Helpful reports include:
 - Reachability flag evaluation should remain deterministic and covered without live network telemetry.
 - Missing SystemConfiguration flag snapshots must fail closed, with tests using
   the internal provider seam rather than inferring behavior from the host route.
+- Deterministic snapshots cover unavailable and reachable routes without live-network dependence.
+- Constrained-path state is not represented by SCNetworkReachabilityFlags; testing it requires a separately reviewed Network framework migration.
 - Automatic connection reachability flags should be evaluated locally and covered without live network telemetry.
 - Automatic connection handling should still require the reachable flag before reporting connectivity.
 - Combined automatic connection flags should stay covered so on-demand and

--- a/VISION.md
+++ b/VISION.md
@@ -21,6 +21,8 @@ Priority:
 - Maintain test coverage for the helper behavior
 - Keep reachability flag evaluation covered by deterministic tests
 - Keep snapshot acquisition failure covered without a live network dependency
+- Deterministic snapshots cover unavailable and reachable routes without live-network dependence.
+- Constrained-path state is not represented by SCNetworkReachabilityFlags; testing it requires a separately reviewed Network framework migration.
 - Keep automatic connection reachability flags covered without live network state
 - Keep automatic connection behavior constrained so it requires the reachable flag
 - Keep combined automatic connection flags covered in fixture tests
@@ -58,7 +60,6 @@ Priority:
 Next priorities:
 
 - Modernize Swift/project settings in a dedicated pass
-- Add tests for offline, online, and constrained network cases where practical
 - Run `pod spec lint NetworkState.podspec` on macOS before any package release
 
 Contribution rules:

--- a/docs/plans/2026-06-26-network-test-roadmap-design.md
+++ b/docs/plans/2026-06-26-network-test-roadmap-design.md
@@ -1,0 +1,41 @@
+# Network Test Roadmap Reconciliation Design
+
+## Context
+
+The roadmap still asks for offline, online, and constrained-network tests. The
+merged deterministic snapshot seam now covers unavailable (`nil` and empty
+flags) and reachable flag snapshots without depending on the host network.
+
+Apple documents `SCNetworkReachabilityFlags` as route-reachability,
+connection-establishment, intervention, local/direct, and WWAN flags. It does
+not expose Low Data Mode or a constrained-path property. Apple exposes that
+property through Network framework path APIs instead:
+
+- <https://developer.apple.com/documentation/systemconfiguration/scnetworkreachabilityflags>
+- <https://developer.apple.com/documentation/network/3131049-nw_path_is_constrained>
+
+## Options Considered
+
+1. Keep the stale roadmap item. This understates completed deterministic
+   coverage and suggests a constrained flag can be added to the current API.
+2. Add Network framework monitoring now. This expands the public and lifecycle
+   surface, conflicts with the iOS 8 compatibility boundary, and is not needed
+   to validate the current synchronous Boolean helper.
+3. Reconcile documentation and contracts. Mark offline/online snapshot coverage
+   complete, document that constrained paths require a separately reviewed
+   Network framework migration, and preserve current behavior.
+
+## Decision
+
+Use option 3. Do not change Swift code, public API, deployment targets, or
+package metadata. Add an exact documentation contract across contributor,
+README, security, roadmap, history, and a completed implementation plan.
+
+## Verification
+
+- Add the static contract first and observe it fail against stale guidance.
+- Update the required documents and mark the implementation plan completed.
+- Mutate the roadmap retirement, constrained-framework boundary, and completed
+  plan in isolated copies; each mutation must fail.
+- Run every Make alias from repository and external directories, plus hosted
+  Xcode and CodeQL on the exact PR head.

--- a/docs/plans/2026-06-26-network-test-roadmap.md
+++ b/docs/plans/2026-06-26-network-test-roadmap.md
@@ -1,0 +1,62 @@
+# Network Test Roadmap Reconciliation Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use executing-plans to implement this plan task-by-task.
+
+**Goal:** Reconcile the network-test roadmap with deterministic snapshot coverage and the constrained-path API boundary.
+
+**Architecture:** Preserve the legacy synchronous `SCNetworkReachability` implementation and iOS 8 compatibility surface. Enforce exact documentation stating that unavailable/reachable snapshots are covered and constrained-path state requires a separate Network framework migration.
+
+**Tech Stack:** Swift/SystemConfiguration documentation, Python 3 static contracts, GNU Make, GitHub Actions
+
+---
+
+status: completed
+
+### Task 1: Write The Failing Documentation Contract
+
+**Files:**
+- Modify: `scripts/check-baseline.py`
+
+Require the exact snapshot-coverage and constrained-path boundary in maintained
+guidance, require the stale roadmap item to be absent, and require this plan to
+be completed.
+
+Run `make check` and confirm it fails before documentation changes.
+
+### Task 2: Reconcile Maintained Guidance
+
+**Files:**
+- Modify: `AGENTS.md`
+- Modify: `README.md`
+- Modify: `SECURITY.md`
+- Modify: `VISION.md`
+- Modify: `CHANGES.md`
+
+Document completed unavailable/reachable snapshot coverage and the separate
+Network framework compatibility decision needed for constrained-path testing.
+
+### Task 3: Complete Evidence
+
+**Files:**
+- Modify: `docs/plans/2026-06-26-network-test-roadmap.md`
+
+Record red-first evidence, mutation results, root/external Make results, hosted
+boundaries, and completion status.
+
+### Task 4: Validate And Review
+
+Run focused hostile mutations, all Make aliases from repository and external
+working directories, syntax/diff/secret audits, Codex review, and hosted checks.
+Merge only the exact unchanged green head.
+
+## Verification Completed
+
+- Red-first `make check` failed on the pending plan, missing exact guidance in
+  five maintained documents, and stale combined roadmap item.
+- The maintained guidance now distinguishes deterministic unavailable/reachable
+  snapshots from constrained-path state in Network framework.
+- Root and external-directory `make check` plus all six documented Make aliases
+  passed, each including the baseline and 19 Python policy tests.
+- Isolated mutations cover stale roadmap restoration, missing constrained-path
+  guidance, missing snapshot guidance, and incomplete-plan evidence.
+- Hosted macOS remains authoritative for Xcode project compilation and XCTest.

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -100,6 +100,8 @@ REQUIRED = [
     "docs/plans/2026-06-25-cocoapods-source-boundary.md",
     "docs/plans/2026-06-25-local-intelligence-ignore.md",
     "docs/plans/2026-06-26-deterministic-snapshot-provider.md",
+    "docs/plans/2026-06-26-network-test-roadmap-design.md",
+    "docs/plans/2026-06-26-network-test-roadmap.md",
     "docs/readme-overview.svg",
     "tests/test_baseline_contracts.py",
     "tests/test_makefile_root.py",
@@ -625,6 +627,17 @@ def main() -> int:
     snapshot_plan = read("docs/plans/2026-06-26-deterministic-snapshot-provider.md")
     if "Status: Completed" not in snapshot_plan or "make check" not in snapshot_plan:
         failures.append("deterministic snapshot provider plan must record completed verification")
+    network_test_plan = read("docs/plans/2026-06-26-network-test-roadmap.md")
+    if "status: completed" not in network_test_plan.lower() or "make check" not in network_test_plan:
+        failures.append("network test roadmap plan must record completed verification")
+    snapshot_guidance = "Deterministic snapshots cover unavailable and reachable routes without live-network dependence."
+    constrained_guidance = "Constrained-path state is not represented by SCNetworkReachabilityFlags; testing it requires a separately reviewed Network framework migration."
+    for relative_path in ["AGENTS.md", "README.md", "SECURITY.md", "VISION.md", "CHANGES.md"]:
+        source = read(relative_path)
+        if snapshot_guidance not in source or constrained_guidance not in source:
+            failures.append(f"{relative_path} must document the network test roadmap boundary")
+    if "Add tests for offline, online, and constrained network cases where practical" in read("VISION.md"):
+        failures.append("VISION.md must retire the completed and incompatible network test roadmap item")
     documentation_contracts = {
         "README.md": "unavailable snapshots fail closed",
         "SECURITY.md": "Missing SystemConfiguration flag snapshots must fail closed",


### PR DESCRIPTION
## Summary
- retire the stale combined offline/online/constrained test roadmap item
- record that deterministic snapshots already cover unavailable and reachable routes
- document that constrained-path state belongs to Network framework, not `SCNetworkReachabilityFlags`
- preserve the public Boolean API and iOS 8 package boundary

## Validation
- red-first `make check`
- four isolated hostile documentation mutations
- all six Make aliases from repository and `/tmp`
- 19 Python policy tests per alias run
- Python and shell syntax checks
- `git diff --check`
- gitleaks: 75 commits, no leaks

## Runtime boundary
- `xcodebuild` is unavailable locally; hosted framework compilation and XCTest remain authoritative.
- no Swift implementation, deployment target, package metadata, or public API changed.

## Sources
- https://developer.apple.com/documentation/systemconfiguration/scnetworkreachabilityflags
- https://developer.apple.com/documentation/network/3131049-nw_path_is_constrained

## Review
- Codex review was invoked and skipped only because the review service returned HTTP 401 before analysis.
